### PR TITLE
feat!: atomic one-step reads, drop setToOmFile

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -4,7 +4,7 @@ import globals from 'globals';
 import ts from 'typescript-eslint';
 
 export default defineConfig([
-	globalIgnores(['node_modules', 'dist', 'coverage', '.vscode', '.gitignore']),
+	globalIgnores(['node_modules', 'dist', 'coverage', '.vscode', '.gitignore', '.svelte-kit']),
 	...ts.configs.recommended,
 	prettier,
 	{

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"dependencies": {
 				"@mapbox/tilebelt": "^2.0.3",
 				"@mapbox/vector-tile": "^3.0.0",
-				"@openmeteo/file-reader": "^0.0.16",
+				"@openmeteo/file-reader": "^0.0.18",
 				"maplibre-gl": "^5.20.1",
 				"pbf": "^5.1.0",
 				"point-in-polygon-hao": "^1.2.4"
@@ -1055,18 +1055,18 @@
 			}
 		},
 		"node_modules/@openmeteo/file-format-wasm": {
-			"version": "0.0.16",
-			"resolved": "https://registry.npmjs.org/@openmeteo/file-format-wasm/-/file-format-wasm-0.0.16.tgz",
-			"integrity": "sha512-VHqIPVys9rYTYz8g87jYj3friz2dExT4tmKusLlEBU2kzvxWmrWSqswd/3FAznU0ZcQdvHcF2EZz7FvbCRU81A==",
+			"version": "0.0.18",
+			"resolved": "https://registry.npmjs.org/@openmeteo/file-format-wasm/-/file-format-wasm-0.0.18.tgz",
+			"integrity": "sha512-t19P/qFpksYMOai4Kwk8bA44Sb8Q9n6De2V4cnEqAYljJEjPAJCylKOVVFlvdNzVN96Kf78qYPnhA69NKDYndA==",
 			"license": "GPL-2.0-only"
 		},
 		"node_modules/@openmeteo/file-reader": {
-			"version": "0.0.16",
-			"resolved": "https://registry.npmjs.org/@openmeteo/file-reader/-/file-reader-0.0.16.tgz",
-			"integrity": "sha512-B88uMVscPLqdyPGziD7gF0Y2Cy75rORCXSN+EMjfa/qe+VgI1gqHI4cdWZNuCEtU9wDO/4CvWxS77nOFhkVTAQ==",
+			"version": "0.0.18",
+			"resolved": "https://registry.npmjs.org/@openmeteo/file-reader/-/file-reader-0.0.18.tgz",
+			"integrity": "sha512-Bjuo2G9Cg5j3L2EstqaJ3iyugwdROYpA56cK2ISfEnRYCR8KsCWQ18oKAmDn7kUUXftQenzTzQTuFRzbxrLpiA==",
 			"license": "GPL-2.0-only",
 			"dependencies": {
-				"@openmeteo/file-format-wasm": "^0.0.16"
+				"@openmeteo/file-format-wasm": "^0.0.18"
 			}
 		},
 		"node_modules/@oxc-project/types": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
 	"dependencies": {
 		"@mapbox/tilebelt": "^2.0.3",
 		"@mapbox/vector-tile": "^3.0.0",
-		"@openmeteo/file-reader": "^0.0.16",
+		"@openmeteo/file-reader": "^0.0.18",
 		"maplibre-gl": "^5.20.1",
 		"pbf": "^5.1.0",
 		"point-in-polygon-hao": "^1.2.4"

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export { omProtocol } from './om-protocol';
 export {
 	getValueFromLatLong,
 	clearBlockCache,
+	clearBackends,
 	getRanges,
 	getProtocolInstance
 } from './om-protocol-state';

--- a/src/om-file-reader.ts
+++ b/src/om-file-reader.ts
@@ -46,7 +46,6 @@ export const defaultFileReaderConfig: Required<Omit<FileReaderConfig, 'cache'>> 
  * Convenience class for reading from OM-files implementing some utility conversions during reading.
  */
 export class WeatherMapLayerFileReader {
-	private reader?: OmFileReader;
 	readonly cache: BlockCache;
 	readonly config: Required<Omit<FileReaderConfig, 'cache'>>;
 	private readonly allDerivationRules: VariableDerivationRule[];
@@ -64,14 +63,18 @@ export class WeatherMapLayerFileReader {
 		this.cache = config.cache ?? new LruBlockCache(64 * 1024, 128);
 	}
 
-	async setToOmFile(omUrl: string): Promise<void> {
-		this.dispose();
-		const s3Backend = new OmHttpBackend({
+	/**
+	 * Run `fn` with a reader scoped to `omUrl`. The reader is opened for this
+	 * call and disposed afterwards, so the class holds no file state: reads for
+	 * different files can never interleave on a shared reader.
+	 */
+	private withReader<T>(omUrl: string, fn: (reader: OmFileReader) => Promise<T>): Promise<T> {
+		const backend = new OmHttpBackend({
 			url: omUrl,
 			eTagValidation: this.config.eTagValidation,
 			retries: this.config.retries
 		});
-		this.reader = await s3Backend.asCachedReader(this.cache);
+		return backend.withReader(this.cache, fn);
 	}
 
 	private getRanges(ranges: DimensionRange[] | null, dimensions: number[]): DimensionRange[] {
@@ -98,148 +101,168 @@ export class WeatherMapLayerFileReader {
 
 	/** Read variable data using a derivation rule. */
 	private async readWithDerivationRule(
+		reader: OmFileReader,
 		variable: string,
 		rule: VariableDerivationRule,
 		ranges: DimensionRange[] | null,
 		signal?: AbortSignal
 	): Promise<Data> {
-		if (!this.reader) {
-			throw new Error('Reader not initialized. Call setToOmFile() first.');
-		}
-
 		const [primaryVar, secondaryVar] = rule.getSourceVars(variable);
 
 		// Get readers for source variables
-		const primaryReader = await this.reader.getChildByName(primaryVar);
-		if (!primaryReader) {
-			throw new Error(`Primary variable ${primaryVar} not found`);
+		let primaryReader: OmFileReader | null = null;
+		let secondaryReader: OmFileReader | null = null;
+		try {
+			primaryReader = await reader.getChildByName(primaryVar);
+			if (!primaryReader) {
+				throw new Error(`Primary variable ${primaryVar} not found`);
+			}
+
+			secondaryReader = await reader.getChildByName(secondaryVar);
+			if (!secondaryReader) {
+				throw new Error(`Secondary variable ${secondaryVar} not found`);
+			}
+
+			// Read data
+			const dimensions = primaryReader.getDimensions();
+			const readRanges = this.getRanges(ranges, dimensions);
+			const readOptions: OmFileReadOptions<OmDataType.FloatArray> = {
+				type: OmDataType.FloatArray,
+				ranges: readRanges,
+				intoSAB: this.config.useSAB,
+				signal
+			};
+
+			const primaryPromise = primaryReader.read(readOptions);
+			const secondaryPromise = secondaryReader.read(readOptions);
+			const [primaryData, secondaryData] = await Promise.all([primaryPromise, secondaryPromise]);
+
+			// Process using the rule
+			const data = rule.process(primaryData, secondaryData);
+
+			// Every derivation rule defines its quantization scale factor so the
+			// half-quantum threshold offset is always available. `'primary'` inherits
+			// the primary source variable's stored scale factor — exact when `values`
+			// is the primary passed through unchanged (speed/direction, wave), and a
+			// good proxy for derived magnitudes (wind speed from u/v).
+			data.scaleFactor =
+				rule.scaleFactor === 'primary' ? primaryReader.scaleFactor() : rule.scaleFactor;
+
+			return data;
+		} finally {
+			// Child readers hold their own wasm allocations; disposing the scoped
+			// root reader does not free them.
+			primaryReader?.dispose();
+			secondaryReader?.dispose();
 		}
-
-		const secondaryReader = await this.reader.getChildByName(secondaryVar);
-		if (!secondaryReader) {
-			throw new Error(`Secondary variable ${secondaryVar} not found`);
-		}
-
-		// Read data
-		const dimensions = primaryReader.getDimensions();
-		const readRanges = this.getRanges(ranges, dimensions);
-		const readOptions: OmFileReadOptions<OmDataType.FloatArray> = {
-			type: OmDataType.FloatArray,
-			ranges: readRanges,
-			intoSAB: this.config.useSAB,
-			signal
-		};
-
-		const primaryPromise = primaryReader.read(readOptions);
-		const secondaryPromise = secondaryReader.read(readOptions);
-		const [primaryData, secondaryData] = await Promise.all([primaryPromise, secondaryPromise]);
-
-		// Process using the rule
-		const data = rule.process(primaryData, secondaryData);
-
-		// Every derivation rule defines its quantization scale factor so the
-		// half-quantum threshold offset is always available. `'primary'` inherits
-		// the primary source variable's stored scale factor — exact when `values`
-		// is the primary passed through unchanged (speed/direction, wave), and a
-		// good proxy for derived magnitudes (wind speed from u/v).
-		data.scaleFactor =
-			rule.scaleFactor === 'primary' ? primaryReader.scaleFactor() : rule.scaleFactor;
-
-		return data;
 	}
 
 	/**
 	 * Read a single variable directly (no derivation).
 	 */
 	private async readSimpleVariable(
+		reader: OmFileReader,
 		variable: string,
 		ranges: DimensionRange[] | null,
 		signal?: AbortSignal
 	): Promise<Data> {
-		if (!this.reader) {
-			throw new Error('Reader not initialized. Call setToOmFile() first.');
-		}
-
-		const variableReader = await this.reader.getChildByName(variable);
+		const variableReader = await reader.getChildByName(variable);
 		if (!variableReader) {
 			throw new Error(`Variable: ${variable} not found`);
 		}
 
-		const dimensions = variableReader.getDimensions();
-		const readRanges = this.getRanges(ranges, dimensions);
+		try {
+			const dimensions = variableReader.getDimensions();
+			const readRanges = this.getRanges(ranges, dimensions);
 
-		const values = (await variableReader.read({
-			type: OmDataType.FloatArray,
-			ranges: readRanges,
-			intoSAB: this.config.useSAB,
-			signal
-		})) as Float32Array;
+			const values = (await variableReader.read({
+				type: OmDataType.FloatArray,
+				ranges: readRanges,
+				intoSAB: this.config.useSAB,
+				signal
+			})) as Float32Array;
 
-		return { values, directions: undefined, scaleFactor: variableReader.scaleFactor() };
+			return { values, directions: undefined, scaleFactor: variableReader.scaleFactor() };
+		} finally {
+			variableReader.dispose();
+		}
 	}
 
 	/**
-	 * Read a specific variable from the file. Implements on the fly conversion for
-	 * some variables, e.g. uv components are converted to speed and direction.
+	 * Read a specific variable from the given .om file. Implements on the fly
+	 * conversion for some variables, e.g. uv components are converted to speed
+	 * and direction. Selecting the file and reading from it is a single atomic
+	 * step, so concurrent reads of different files cannot interleave.
 	 *
+	 * @param omUrl The .om file URL to read from.
 	 * @param variable The variable to read.
 	 * @param ranges The ranges to read. If null, all dimensions are read.
 	 * @param signal Optional AbortSignal
 	 * @returns Promise resolving to data object containing values and optional directions
 	 */
 	async readVariable(
+		omUrl: string,
 		variable: string,
 		ranges: DimensionRange[] | null = null,
 		signal?: AbortSignal
 	): Promise<Data> {
-		const derivationRule = this.findDerivationRule(variable);
+		return this.withReader(omUrl, (reader) => {
+			const derivationRule = this.findDerivationRule(variable);
 
-		if (derivationRule) {
-			return this.readWithDerivationRule(variable, derivationRule, ranges, signal);
-		} else {
-			return this.readSimpleVariable(variable, ranges, signal);
-		}
+			if (derivationRule) {
+				return this.readWithDerivationRule(reader, variable, derivationRule, ranges, signal);
+			} else {
+				return this.readSimpleVariable(reader, variable, ranges, signal);
+			}
+		});
 	}
 
 	/**
-	 * Prefetch data for a specific variable and range into the local cache.
-	 * This is useful for warming up the cache for anticipated map movements.
+	 * Prefetch data for a specific variable and range of the given .om file into
+	 * the local cache. This is useful for warming up the cache for anticipated
+	 * map movements or timestep changes.
 	 */
 	async prefetchVariable(
+		omUrl: string,
 		variable: string,
 		ranges: DimensionRange[] | null = null,
 		signal?: AbortSignal
 	): Promise<void> {
-		if (!this.reader) return;
+		await this.withReader(omUrl, async (reader) => {
+			const derivationRule = this.findDerivationRule(variable);
+			const varsToPrefetch = derivationRule ? derivationRule.getSourceVars(variable) : [variable];
 
-		const derivationRule = this.findDerivationRule(variable);
-		const varsToPrefetch = derivationRule ? derivationRule.getSourceVars(variable) : [variable];
+			await Promise.all(
+				varsToPrefetch.map(async (v) => {
+					const variableReader = await reader.getChildByName(v);
+					if (!variableReader) return;
 
-		await Promise.all(
-			varsToPrefetch.map(async (v) => {
-				const variableReader = await this.reader!.getChildByName(v);
-				if (!variableReader) return;
+					try {
+						const dimensions = variableReader.getDimensions();
+						const readRanges = this.getRanges(ranges, dimensions);
 
-				const dimensions = variableReader.getDimensions();
-				const readRanges = this.getRanges(ranges, dimensions);
-
-				// readPrefetch warms up the backend cache by requesting the necessary
-				// data blocks without decoding them or copying them to a TypedArray.
-				await variableReader.readPrefetch({
-					prefetchConcurrency: 1000, // concurrency limiting on requests is executed via the BlockCache
-					ranges: readRanges,
-					signal
-				});
-			})
-		);
+						// readPrefetch warms up the backend cache by requesting the necessary
+						// data blocks without decoding them or copying them to a TypedArray.
+						await variableReader.readPrefetch({
+							prefetchConcurrency: 1000, // concurrency limiting on requests is executed via the BlockCache
+							ranges: readRanges,
+							signal
+						});
+					} finally {
+						variableReader.dispose();
+					}
+				})
+			);
+		});
 	}
 
-	dispose() {
-		if (this.reader) {
-			this.reader.dispose();
-		}
-
-		delete this.reader;
+	/**
+	 * Warm the cache for the given .om file: opening the scoped reader fetches
+	 * the file header/trailer and root metadata into the block cache, so a later
+	 * read only pays for its data blocks. No variable data is requested.
+	 */
+	async warmFile(omUrl: string): Promise<void> {
+		await this.withReader(omUrl, async () => {});
 	}
 }
 

--- a/src/om-file-reader.ts
+++ b/src/om-file-reader.ts
@@ -4,7 +4,7 @@ import {
 	OmDataType,
 	OmFileReadOptions,
 	type OmFileReader,
-	OmHttpBackend
+	OmHttpBackendPool
 } from '@openmeteo/file-reader';
 
 import { fastAtan2, radiansToDegrees } from './utils/math';
@@ -49,6 +49,8 @@ export class WeatherMapLayerFileReader {
 	readonly cache: BlockCache;
 	readonly config: Required<Omit<FileReaderConfig, 'cache'>>;
 	private readonly allDerivationRules: VariableDerivationRule[];
+	/** Memoizes one backend per URL, so repeat reads skip the HEAD request. */
+	private readonly backendPool: OmHttpBackendPool;
 
 	constructor(config: FileReaderConfig = {}) {
 		this.config = {
@@ -61,20 +63,24 @@ export class WeatherMapLayerFileReader {
 
 		// Use the injected cache, or fall back to an in-memory LRU cache
 		this.cache = config.cache ?? new LruBlockCache(64 * 1024, 128);
+
+		this.backendPool = new OmHttpBackendPool({
+			backendOptions: {
+				eTagValidation: this.config.eTagValidation,
+				retries: this.config.retries
+			}
+		});
 	}
 
 	/**
 	 * Run `fn` with a reader scoped to `omUrl`. The reader is opened for this
 	 * call and disposed afterwards, so the class holds no file state: reads for
-	 * different files can never interleave on a shared reader.
+	 * different files can never interleave on a shared reader. The backend pool
+	 * only memoizes per-URL HTTP metadata (no wasm resources), keeping repeat
+	 * opens cheap without reintroducing shared reader state.
 	 */
 	private withReader<T>(omUrl: string, fn: (reader: OmFileReader) => Promise<T>): Promise<T> {
-		const backend = new OmHttpBackend({
-			url: omUrl,
-			eTagValidation: this.config.eTagValidation,
-			retries: this.config.retries
-		});
-		return backend.withReader(this.cache, fn);
+		return this.backendPool.withReader(omUrl, this.cache, fn);
 	}
 
 	private getRanges(ranges: DimensionRange[] | null, dimensions: number[]): DimensionRange[] {
@@ -263,6 +269,11 @@ export class WeatherMapLayerFileReader {
 	 */
 	async warmFile(omUrl: string): Promise<void> {
 		await this.withReader(omUrl, async () => {});
+	}
+
+	/** Drop all memoized backends, forcing fresh HEAD metadata requests. */
+	clearBackends(): void {
+		this.backendPool.clear();
 	}
 }
 

--- a/src/om-protocol-state.ts
+++ b/src/om-protocol-state.ts
@@ -171,9 +171,8 @@ export const ensureData = async (
 
 		state.dataPromise = (async () => {
 			try {
-				await omFileReader.setToOmFile(state.omFileUrl);
-
 				const data = await omFileReader.readVariable(
+					state.omFileUrl,
 					state.dataOptions.variable,
 					state.ranges,
 					controller.signal

--- a/src/om-protocol-state.ts
+++ b/src/om-protocol-state.ts
@@ -64,6 +64,11 @@ export const clearBlockCache = async (): Promise<void> => {
 	omProtocolInstance?.stateByKey.clear();
 };
 
+/** Drop all memoized HTTP backends, so the next read re-fetches file metadata. */
+export const clearBackends = (): void => {
+	omProtocolInstance?.omFileReader.clearBackends();
+};
+
 export const getRanges = (gridData: GridData, bounds: Bounds | undefined): DimensionRange[] => {
 	if (bounds) {
 		const gridGetter = GridFactory.create(gridData, null);

--- a/src/tests/om-protocol-state.test.ts
+++ b/src/tests/om-protocol-state.test.ts
@@ -65,11 +65,12 @@ class FakeReader {
 	calls: ReadCall[] = [];
 
 	// Must match the WeatherMapLayerFileReader interface used by ensureData
-	async setToOmFile(_url?: string): Promise<void> {
-		// intentional no-op
-	}
-
-	readVariable(variable: unknown, ranges: unknown, signal?: AbortSignal): Promise<Data> {
+	readVariable(
+		_url: unknown,
+		variable: unknown,
+		ranges: unknown,
+		signal?: AbortSignal
+	): Promise<Data> {
 		return new Promise<Data>((resolve, reject) => {
 			const call: ReadCall = { variable, ranges, signal, resolve, reject, aborted: false };
 			this.calls.push(call);

--- a/src/tests/om-protocol.test.ts
+++ b/src/tests/om-protocol.test.ts
@@ -22,8 +22,7 @@ vi.mock('../om-file-reader', async () => {
 		...actual,
 		WeatherMapLayerFileReader: class {
 			config = {};
-			async setToOmFile() {}
-			async readVariable(_variable: string, ranges: DimensionRange[]) {
+			async readVariable(_url: string, _variable: string, ranges: DimensionRange[]) {
 				if (mockReadVariableResult.value) {
 					return mockReadVariableResult.value;
 				}


### PR DESCRIPTION
### Summary

`setToOmFile()` + `readVariable()` was a two-step mutation of shared reader state:
concurrent callers could interleave between the steps, silently reading the wrong
file or disposing a reader another call was mid-read on.

`readVariable`/`prefetchVariable` now take the URL and use a scoped per-call reader
`OmHttpBackend.withReader` child readers are disposed as well. New `warmFile(url)`
replaces the `prefetchVariable('not_a_real_variable')` warmup trick.

Breaking: `setToOmFile()` and `dispose()` are removed. Requires
`@openmeteo/file-reader` > 0.0.16.