### PR TITLE
fix: circular direction interpolation

### DIFF
--- a/src/grids/gaussian.ts
+++ b/src/grids/gaussian.ts
@@ -1,7 +1,12 @@
 import { modPositive, roundWithPrecision } from '../utils/math';
 
 import { GridInterface, GridPoint } from './interface';
-import { bilinearNaNAware, catmullRom1D, monotoneHermite } from './interpolations';
+import {
+	bilinearAngleNaNAware,
+	bilinearNaNAware,
+	catmullRom1D,
+	monotoneHermite
+} from './interpolations';
 
 import { Bounds, DimensionRange, GaussianGridData, InterpolationMethod } from '../types';
 
@@ -190,8 +195,23 @@ export class GaussianGrid implements GridInterface {
 		return { v, p0, p1 };
 	}
 
-	/// Values is the 1D array of all HRES values (6 million something values)
-	getLinearInterpolatedValue(values: Float32Array, lat: number, lon: number): number {
+	/**
+	 * The four samples bracketing a coordinate plus the trapezoidal-cell
+	 * fractions, shared by the scalar and the angular linear interpolation.
+	 */
+	private linearStencil(
+		values: Float32Array,
+		lat: number,
+		lon: number
+	): {
+		p0: number;
+		p1: number;
+		p2: number;
+		p3: number;
+		xFractionLower: number;
+		xFractionUpper: number;
+		yFraction: number;
+	} {
 		const latitudeLines = this.latitudeLines;
 		const dy = 180 / (2 * latitudeLines + 0.5);
 		const yLower = modPositive(
@@ -211,17 +231,45 @@ export class GaussianGrid implements GridInterface {
 		const xFractionLower = modPositive(lon / dxLower, 1);
 		const xFractionUpper = modPositive(lon / dxUpper, 1);
 
+		return {
+			p0: values[integralLower + xLower0],
+			p1: values[integralLower + ((xLower0 + 1) % nxLower)],
+			p2: values[integralUpper + xUpper0],
+			p3: values[integralUpper + ((xUpper0 + 1) % nxUpper)],
+			xFractionLower,
+			xFractionUpper,
+			yFraction
+		};
+	}
+
+	/// Values is the 1D array of all HRES values (6 million something values)
+	getLinearInterpolatedValue(values: Float32Array, lat: number, lon: number): number {
+		const s = this.linearStencil(values, lat, lon);
+
 		// The two rows have a different number of longitude points, so the cell is
 		// a trapezoid (xFractionLower != xFractionUpper); the shared NaN-aware
 		// bilinear handles that and the masked-corner triangle cases.
 		return bilinearNaNAware(
-			values[integralLower + xLower0],
-			values[integralLower + ((xLower0 + 1) % nxLower)],
-			values[integralUpper + xUpper0],
-			values[integralUpper + ((xUpper0 + 1) % nxUpper)],
-			xFractionLower,
-			xFractionUpper,
-			yFraction
+			s.p0,
+			s.p1,
+			s.p2,
+			s.p3,
+			s.xFractionLower,
+			s.xFractionUpper,
+			s.yFraction
+		);
+	}
+
+	getLinearInterpolatedDirection(values: Float32Array, lat: number, lon: number): number {
+		const s = this.linearStencil(values, lat, lon);
+		return bilinearAngleNaNAware(
+			s.p0,
+			s.p1,
+			s.p2,
+			s.p3,
+			s.xFractionLower,
+			s.xFractionUpper,
+			s.yFraction
 		);
 	}
 

--- a/src/grids/interface.ts
+++ b/src/grids/interface.ts
@@ -10,6 +10,13 @@ export interface GridInterface {
 	getLinearInterpolatedValue(values: Float32Array, lat: number, lon: number): number;
 
 	/**
+	 * Samples an angular field in degrees with circular linear interpolation, so
+	 * values blend across the 0°/360° seam (halfway between 359° and 1° is 0°,
+	 * not the 180° scalar interpolation would give). Returns degrees in [0, 360).
+	 */
+	getLinearInterpolatedDirection(values: Float32Array, lat: number, lon: number): number;
+
+	/**
 	 * Samples the grid at the given geographic coordinate using the requested
 	 * interpolation method.
 	 */

--- a/src/grids/interpolations.ts
+++ b/src/grids/interpolations.ts
@@ -1,4 +1,4 @@
-import { modPositive, roundWithPrecision } from '../utils/math';
+import { degreesToRadians, modPositive, radiansToDegrees, roundWithPrecision } from '../utils/math';
 
 export const interpolateNearest = (
 	values: Float32Array,
@@ -87,15 +87,22 @@ export const bilinearNaNAware = (
 	return NaN;
 };
 
-/** Moves `degrees` onto the continuous scale around `reference` (shortest arc). */
-const unwrapAngle = (reference: number, degrees: number): number =>
-	reference + (((degrees - reference + 540) % 360) - 180);
-
 /**
  * The NaN-aware bilinear for an angular field in degrees. Angles cannot be
- * blended as scalars — halfway between 359° and 1° is 0°, not 180° — so the
- * corners are unwrapped onto a continuous scale around a finite reference
- * corner first, and the blend is wrapped back to [0, 360).
+ * blended as scalars — halfway between 359° and 1° is 0°, not 180° — so each
+ * corner becomes a unit vector, the two components are blended by the same
+ * NaN-aware bilinear as any scalar field, and the resultant is turned back into
+ * an angle. That is the circular mean, i.e. exactly what interpolating the u/v
+ * components of a unit-speed wind would give.
+ *
+ * `Math.sin`/`Math.cos` map NaN to NaN, so both component blends see the same
+ * missing corners and take the same triangle branch. The blend only has to be
+ * proportional to the resultant vector — `atan2` is scale invariant — so the
+ * triangle branch's weight renormalization is harmless here.
+ *
+ * The resultant is degenerate (zero length) only when the contributing corners
+ * cancel exactly, e.g. two equally weighted corners 180° apart; there is no
+ * meaningful mean direction in that case and `atan2(0, 0)` returns 0°.
  */
 export const bilinearAngleNaNAware = (
 	p0: number,
@@ -106,17 +113,32 @@ export const bilinearAngleNaNAware = (
 	xfUpper: number,
 	yFraction: number
 ): number => {
-	const reference = isFinite(p0) ? p0 : isFinite(p1) ? p1 : isFinite(p2) ? p2 : p3;
-	const blended = bilinearNaNAware(
-		unwrapAngle(reference, p0),
-		unwrapAngle(reference, p1),
-		unwrapAngle(reference, p2),
-		unwrapAngle(reference, p3),
+	const r0 = degreesToRadians(p0);
+	const r1 = degreesToRadians(p1);
+	const r2 = degreesToRadians(p2);
+	const r3 = degreesToRadians(p3);
+
+	const y = bilinearNaNAware(
+		Math.sin(r0),
+		Math.sin(r1),
+		Math.sin(r2),
+		Math.sin(r3),
 		xfLower,
 		xfUpper,
 		yFraction
 	);
-	return modPositive(blended, 360);
+	const x = bilinearNaNAware(
+		Math.cos(r0),
+		Math.cos(r1),
+		Math.cos(r2),
+		Math.cos(r3),
+		xfLower,
+		xfUpper,
+		yFraction
+	);
+	if (!isFinite(y) || !isFinite(x)) return NaN;
+
+	return modPositive(radiansToDegrees(Math.atan2(y, x)), 360);
 };
 
 export const interpolateLinear = (

--- a/src/grids/interpolations.ts
+++ b/src/grids/interpolations.ts
@@ -1,4 +1,4 @@
-import { roundWithPrecision } from '../utils/math';
+import { modPositive, roundWithPrecision } from '../utils/math';
 
 export const interpolateNearest = (
 	values: Float32Array,
@@ -87,6 +87,38 @@ export const bilinearNaNAware = (
 	return NaN;
 };
 
+/** Moves `degrees` onto the continuous scale around `reference` (shortest arc). */
+const unwrapAngle = (reference: number, degrees: number): number =>
+	reference + (((degrees - reference + 540) % 360) - 180);
+
+/**
+ * The NaN-aware bilinear for an angular field in degrees. Angles cannot be
+ * blended as scalars — halfway between 359° and 1° is 0°, not 180° — so the
+ * corners are unwrapped onto a continuous scale around a finite reference
+ * corner first, and the blend is wrapped back to [0, 360).
+ */
+export const bilinearAngleNaNAware = (
+	p0: number,
+	p1: number,
+	p2: number,
+	p3: number,
+	xfLower: number,
+	xfUpper: number,
+	yFraction: number
+): number => {
+	const reference = isFinite(p0) ? p0 : isFinite(p1) ? p1 : isFinite(p2) ? p2 : p3;
+	const blended = bilinearNaNAware(
+		unwrapAngle(reference, p0),
+		unwrapAngle(reference, p1),
+		unwrapAngle(reference, p2),
+		unwrapAngle(reference, p3),
+		xfLower,
+		xfUpper,
+		yFraction
+	);
+	return modPositive(blended, 360);
+};
+
 export const interpolateLinear = (
 	values: Float32Array,
 	x: number,
@@ -117,6 +149,46 @@ export const interpolateLinear = (
 
 	// Rectangular cell: both edges share the same horizontal fraction.
 	return bilinearNaNAware(
+		values[index],
+		values[nextIndex],
+		values[index + nx],
+		values[nextIndex + nx],
+		xFraction,
+		xFraction,
+		yFraction
+	);
+};
+
+/** `interpolateLinear` for an angular field in degrees (see `bilinearAngleNaNAware`). */
+export const interpolateLinearAngle = (
+	values: Float32Array,
+	x: number,
+	y: number,
+	xFraction: number,
+	yFraction: number,
+	nx: number,
+	longitudeWrap: boolean = false
+): number => {
+	const index = y * nx + x;
+
+	let nextIndex: number;
+	if (longitudeWrap) {
+		// For global grids, data can wrap to the other side
+		nextIndex = y * nx + ((x + 1) % nx);
+	} else {
+		nextIndex = index + 1;
+		// Right border
+		if (nextIndex % nx === 0) {
+			return NaN;
+		}
+	}
+
+	// Bottom border
+	if (index + nx > values.length) {
+		return NaN;
+	}
+
+	return bilinearAngleNaNAware(
 		values[index],
 		values[nextIndex],
 		values[index + nx],

--- a/src/grids/projected.ts
+++ b/src/grids/projected.ts
@@ -2,6 +2,7 @@ import { GridInterface, GridPoint } from './interface';
 import {
 	interpolateCubic,
 	interpolateLinear,
+	interpolateLinearAngle,
 	interpolateMonotone,
 	interpolateNearest
 } from './interpolations';
@@ -88,6 +89,11 @@ export class ProjectionGrid implements GridInterface {
 
 	getLinearInterpolatedValue(values: Float32Array, lat: number, lon: number): number {
 		return this.getInterpolatedValue(values, lat, lon, 'linear');
+	}
+
+	getLinearInterpolatedDirection(values: Float32Array, lat: number, lon: number): number {
+		const idx = this.findPointInterpolated(lat, lon);
+		return interpolateLinearAngle(values, idx.x, idx.y, idx.xFraction, idx.yFraction, this.nx);
 	}
 
 	getInterpolatedValue(

--- a/src/grids/regular.ts
+++ b/src/grids/regular.ts
@@ -2,6 +2,7 @@ import { GridInterface, GridPoint } from './interface';
 import {
 	interpolateCubic,
 	interpolateLinear,
+	interpolateLinearAngle,
 	interpolateMonotone,
 	interpolateNearest
 } from './interpolations';
@@ -109,29 +110,24 @@ export class RegularGrid implements GridInterface {
 		this.wrapLastCellDouble = this.longitudeWrap && lonSpan < 360 - 0.5 * absDx;
 	}
 
-	getLinearInterpolatedValue(values: Float32Array, lat: number, lon: number): number {
-		return this.getInterpolatedValue(values, lat, lon, 'linear');
-	}
-
-	getInterpolatedValue(
-		values: Float32Array,
+	/** Grid cell and in-cell fractions for a coordinate, or null outside the grid. */
+	private locate(
 		lat: number,
-		lon: number,
-		method: InterpolationMethod
-	): number {
+		lon: number
+	): { x: number; y: number; xFraction: number; yFraction: number } | null {
 		// Compute floating-point grid indices from origin
 		const xRaw = (lon - this.originLon) / this.dx;
 		const yRaw = (lat - this.originLat) / this.dy;
 
 		// Check y bounds (works for both positive and negative dy)
 		if (yRaw < 0 || yRaw >= this.ny) {
-			return NaN;
+			return null;
 		}
 
 		// Check x bounds
 		if (!this.longitudeWrap) {
 			if (xRaw < 0 || xRaw >= this.nx) {
-				return NaN;
+				return null;
 			}
 		}
 
@@ -144,6 +140,41 @@ export class RegularGrid implements GridInterface {
 		const absDx = Math.abs(this.dx);
 		const effectiveDx = this.wrapLastCellDouble && xRaw >= this.nx - 1 ? absDx * 2 : absDx;
 		const xFraction = Math.abs((lon - this.originLon) % effectiveDx) / effectiveDx;
+
+		return { x, y, xFraction, yFraction };
+	}
+
+	getLinearInterpolatedValue(values: Float32Array, lat: number, lon: number): number {
+		return this.getInterpolatedValue(values, lat, lon, 'linear');
+	}
+
+	getLinearInterpolatedDirection(values: Float32Array, lat: number, lon: number): number {
+		const cell = this.locate(lat, lon);
+		if (!cell) {
+			return NaN;
+		}
+		return interpolateLinearAngle(
+			values,
+			cell.x,
+			cell.y,
+			cell.xFraction,
+			cell.yFraction,
+			this.nx,
+			this.longitudeWrap
+		);
+	}
+
+	getInterpolatedValue(
+		values: Float32Array,
+		lat: number,
+		lon: number,
+		method: InterpolationMethod
+	): number {
+		const cell = this.locate(lat, lon);
+		if (!cell) {
+			return NaN;
+		}
+		const { x, y, xFraction, yFraction } = cell;
 
 		switch (method) {
 			// 'nearest' returns the value of the closest grid node (round), centred on the node exactly like the

--- a/src/om-protocol-state.ts
+++ b/src/om-protocol-state.ts
@@ -234,7 +234,16 @@ export const getValueFromLatLong = async (
 	const interpolation = resolveInterpolation(params.get('interpolation'));
 	const value = grid.getInterpolatedValue(state.data.values, lat, lonNormalized, interpolation);
 
-	return { value };
+	// Derived variables (u/v components, speed+direction, wave height+direction)
+	// carry a direction field. Sampled the same way the arrows are (circular on
+	// the degrees), so a popup arrow points exactly like the arrow under it.
+	const directions = state.data.directions;
+	if (!directions) return { value };
+
+	return {
+		value,
+		direction: grid.getLinearInterpolatedDirection(directions, lat, lonNormalized)
+	};
 };
 
 /** Parse the `interpolation` URL param, falling back to the default on absent or invalid values. */

--- a/src/tests/grids.test.ts
+++ b/src/tests/grids.test.ts
@@ -157,6 +157,25 @@ describe('RegularGrid', () => {
 		expect(grid.getLinearInterpolatedValue(values, 100, 100)).toBeNaN();
 	});
 
+	test('direction interpolation crosses the 0°/360° seam', () => {
+		const grid = new RegularGrid(gridData);
+		// Column 1 blows from 350°, column 2 from 10°: halfway between them the
+		// wind comes from due north, not from the 180° a scalar blend would give
+		const directions = new Float32Array(30).fill(350);
+		for (let row = 0; row < 3; row++) {
+			directions[row * 10 + 2] = 10;
+		}
+		expect(grid.getLinearInterpolatedDirection(directions, 52, 11.5)).toBeCloseTo(0);
+		// Away from the seam it matches the scalar interpolation
+		directions.fill(30);
+		for (let row = 0; row < 3; row++) {
+			directions[row * 10 + 2] = 50;
+		}
+		expect(grid.getLinearInterpolatedDirection(directions, 52, 11.5)).toBeCloseTo(40);
+		// Out-of-bounds behaves like the scalar sampler
+		expect(grid.getLinearInterpolatedDirection(directions, 100, 100)).toBeNaN();
+	});
+
 	describe('RegularGrid with negative dy', () => {
 		test('constructs and computes bounds (normalized min <= max)', () => {
 			const grid = new RegularGrid(gridDataNegDy);

--- a/src/tests/interpolations.test.ts
+++ b/src/tests/interpolations.test.ts
@@ -1,0 +1,35 @@
+import { bilinearAngleNaNAware, bilinearNaNAware } from '../grids/interpolations';
+import { describe, expect, test } from 'vitest';
+
+describe('bilinearAngleNaNAware', () => {
+	test('blends across the 0°/360° seam', () => {
+		// Halfway between 350° and 10° is due north, not the 180° a scalar blend gives
+		expect(bilinearAngleNaNAware(350, 10, 350, 10, 0.5, 0.5, 0.5)).toBeCloseTo(0);
+	});
+
+	test('matches the scalar blend away from the seam', () => {
+		expect(bilinearAngleNaNAware(30, 50, 30, 50, 0.5, 0.5, 0.5)).toBeCloseTo(40);
+	});
+
+	test('ignores corners that carry no weight', () => {
+		// xf = 1 and yFraction = 0.5 → only p1 and p3 contribute; their mean is 180°.
+		// Unwrapping around p0 used to map them to 170°/-170° and return 0°, i.e. a
+		// flipped arrow.
+		expect(bilinearAngleNaNAware(0, 170, 0, 190, 1, 1, 0.5)).toBeCloseTo(180);
+	});
+
+	test('keeps the NaN/triangle handling of the scalar bilinear', () => {
+		// Two missing corners → no valid triangle
+		expect(bilinearAngleNaNAware(NaN, 10, NaN, 20, 0.5, 0.5, 0.5)).toBeNaN();
+		// p0 missing and the sample outside the remaining triangle
+		expect(bilinearAngleNaNAware(NaN, 10, 20, 30, 0.2, 0.2, 0.2)).toBeNaN();
+		expect(bilinearNaNAware(NaN, 10, 20, 30, 0.2, 0.2, 0.2)).toBeNaN();
+		// p0 missing and the sample inside it → the remaining three corners blend.
+		// The circular mean pulls slightly off the scalar mean (a chord is shorter
+		// than its arc), so this is close to, not equal to, the scalar result.
+		expect(bilinearAngleNaNAware(NaN, 10, 20, 30, 0.8, 0.8, 0.8)).toBeCloseTo(
+			bilinearNaNAware(NaN, 10, 20, 30, 0.8, 0.8, 0.8),
+			1
+		);
+	});
+});

--- a/src/utils/arrows.ts
+++ b/src/utils/arrows.ts
@@ -49,10 +49,11 @@ export const generateArrows = (
 			}
 
 			// Sample speed with the selected method so arrow size/colour matches
-			// the raster; direction stays linear (averaging angles would be wrong).
+			// the raster; direction is blended circularly (scalar averaging flips
+			// arrows near the 0°/360° seam).
 			const speed = grid.getInterpolatedValue(values, lat, lon, interpolation);
 			const direction = degreesToRadians(
-				grid.getLinearInterpolatedValue(directions, lat, lon) + 180
+				grid.getLinearInterpolatedDirection(directions, lat, lon) + 180
 			);
 
 			const properties: { value?: number; direction?: number } = {


### PR DESCRIPTION
### Summary

- Seperate interpolation for directional fields.
- Returns direction as well from `getValueFromLatLong()` (for popup visualisation)