### PR TITLE
fix: cancel data reads for abandoned frames

### DIFF
--- a/src/om-protocol-state.ts
+++ b/src/om-protocol-state.ts
@@ -23,6 +23,8 @@ import type {
 interface InflightRequest {
 	controller: AbortController;
 	subscriberCount: number;
+	/** The read this entry owns — identifies it once it settles. */
+	promise?: Promise<Data>;
 }
 
 const inflightRequests = new WeakMap<OmUrlState, InflightRequest>();
@@ -126,6 +128,58 @@ export const getOrCreateState = (
 };
 
 /**
+ * Starts the shared read for a state, or joins the one already running,
+ * **without becoming a subscriber of it**: the caller gets the data, but its
+ * presence never keeps the read alive. Use it to warm the cache up front (the
+ * TileJSON request does, so the download overlaps MapLibre setting the source
+ * up); a warm-up that counted as a subscriber could never be released, and
+ * the read would go on downloading long after every tile of that frame was
+ * abandoned.
+ *
+ * A read whose subscribers have all aborted is no longer joinable even while
+ * its rejection is still in flight — the next caller starts a fresh one
+ * instead of inheriting a cancellation it did not ask for.
+ */
+export const startData = (
+	state: OmUrlState,
+	omFileReader: WeatherMapLayerFileReader,
+	postReadCallback: PostReadCallback
+): Promise<Data> => {
+	const running = state.dataPromise;
+	if (running && inflightRequests.has(state)) return running;
+
+	const entry: InflightRequest = { controller: new AbortController(), subscriberCount: 0 };
+	inflightRequests.set(state, entry);
+
+	const promise = (async () => {
+		try {
+			const data = await omFileReader.readVariable(
+				state.omFileUrl,
+				state.dataOptions.variable,
+				state.ranges,
+				entry.controller.signal
+			);
+
+			if (postReadCallback) {
+				postReadCallback(omFileReader, data, state);
+			}
+
+			state.data = data;
+			return data;
+		} finally {
+			// Only clear what still belongs to this read: an abandoned one can
+			// have been replaced by a fresh read before it settles
+			if (state.dataPromise === entry.promise) state.dataPromise = null;
+			if (inflightRequests.get(state) === entry) inflightRequests.delete(state);
+		}
+	})();
+	entry.promise = promise;
+	state.dataPromise = promise;
+
+	return promise;
+};
+
+/**
  * Ensures that data for a given state is loaded.
  * Handles multiple concurrent requests for the same data by sharing a promise.
  * Correctly handles AbortSignals by tracking all active subscribers and
@@ -140,26 +194,23 @@ export const ensureData = async (
 	if (state.data) return state.data;
 	if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
 
+	const pending = startData(state, omFileReader, postReadCallback);
 	const inflight = inflightRequests.get(state);
-	const subscriberCount = (inflight?.subscriberCount ?? 0) + 1;
-
-	if (inflight) {
-		inflight.subscriberCount = subscriberCount;
-	}
+	if (inflight) inflight.subscriberCount += 1;
 
 	let finished = false;
 	const cleanup = () => {
 		if (finished) return;
 		finished = true;
 
-		const current = inflightRequests.get(state);
-		if (!current) return;
+		// Not `inflightRequests.get(state)`: our read may already have been
+		// replaced, and releasing a subscriber of the newer one would abort it
+		if (!inflight || inflightRequests.get(state) !== inflight) return;
 
-		if (current.subscriberCount <= 1) {
+		inflight.subscriberCount -= 1;
+		if (inflight.subscriberCount <= 0) {
 			inflightRequests.delete(state);
-			current.controller.abort();
-		} else {
-			current.subscriberCount -= 1;
+			inflight.controller.abort();
 		}
 	};
 
@@ -168,35 +219,7 @@ export const ensureData = async (
 	}
 
 	try {
-		if (state.dataPromise) {
-			return await state.dataPromise;
-		}
-
-		const controller = new AbortController();
-		inflightRequests.set(state, { controller, subscriberCount });
-
-		state.dataPromise = (async () => {
-			try {
-				const data = await omFileReader.readVariable(
-					state.omFileUrl,
-					state.dataOptions.variable,
-					state.ranges,
-					controller.signal
-				);
-
-				if (postReadCallback) {
-					postReadCallback(omFileReader, data, state);
-				}
-
-				state.data = data;
-				return data;
-			} finally {
-				state.dataPromise = null;
-				inflightRequests.delete(state);
-			}
-		})();
-
-		return await state.dataPromise;
+		return await pending;
 	} finally {
 		if (signal) {
 			signal.removeEventListener('abort', cleanup);

--- a/src/om-protocol.ts
+++ b/src/om-protocol.ts
@@ -9,7 +9,7 @@ import { COLOR_SCALES_WITH_ALIASES as defaultColorScales } from './utils/styling
 import { domainOptions as defaultDomainOptions } from './domains';
 import { GridFactory } from './grids/index';
 import { defaultFileReaderConfig } from './om-file-reader';
-import { ensureData, getOrCreateState, getProtocolInstance } from './om-protocol-state';
+import { ensureData, getOrCreateState, getProtocolInstance, startData } from './om-protocol-state';
 import { capitalize } from './utils';
 import { WorkerPool } from './worker-pool';
 
@@ -75,8 +75,10 @@ export const omProtocol = async (
 	// data download. The data load is still kicked off right away (fire and
 	// forget) so it runs while MapLibre processes the TileJSON — the subsequent
 	// tile requests then await the same shared promise via state.dataPromise.
+	// `startData`, not `ensureData`: the warm-up must not subscribe, or the read
+	// would outlive the tiles it was started for and could never be cancelled.
 	if (params.type == 'json') {
-		ensureData(state, instance.omFileReader, settings.postReadCallback).catch(() => {
+		startData(state, instance.omFileReader, settings.postReadCallback).catch(() => {
 			// Errors surface on the awaited tile requests; ignore here.
 		});
 		return {

--- a/src/tests/om-protocol-state.test.ts
+++ b/src/tests/om-protocol-state.test.ts
@@ -1,5 +1,5 @@
 import type { WeatherMapLayerFileReader } from '../om-file-reader';
-import { ensureData, getOrCreateState, getRanges } from '../om-protocol-state';
+import { ensureData, getOrCreateState, getRanges, startData } from '../om-protocol-state';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type {
@@ -422,6 +422,79 @@ describe('ensureData – error state', () => {
 		// The underlying read rejects the way a cancelled fetch does
 		reader.rejectCall(0, new DOMException('Aborted', 'AbortError'));
 		await expect(p).rejects.toMatchObject({ name: 'AbortError' });
+		expect(state.dataPromise).toBeNull();
+	});
+});
+
+describe('startData – warm-up', () => {
+	it('does not keep a read alive that all subscribers cancelled', async () => {
+		const state = makeState(new Map(), 'warm-up');
+		const reader = new FakeReader();
+
+		// The TileJSON request warms the data up before any tile asks for it
+		startData(state, asReader(reader), undefined).catch(() => {});
+		await flushMicrotasks();
+		expect(reader.calls).toHaveLength(1);
+
+		const ac = new AbortController();
+		const tile = ensureData(state, asReader(reader), undefined, ac.signal);
+		await flushMicrotasks();
+
+		// The tile joins the warmed-up read instead of starting a second one
+		expect(reader.calls).toHaveLength(1);
+		expect(reader.calls[0].signal!.aborted).toBe(false);
+
+		// ...and cancelling it cancels the read, warm-up notwithstanding
+		ac.abort();
+		expect(reader.calls[0].signal!.aborted).toBe(true);
+		await expect(tile).rejects.toThrow();
+	});
+
+	it('completes when no subscriber ever joins', async () => {
+		const state = makeState(new Map(), 'warm-up-alone');
+		const reader = new FakeReader();
+
+		const warm = startData(state, asReader(reader), undefined);
+		await flushMicrotasks();
+
+		const mockData = makeMockData();
+		reader.resolveCall(0, mockData);
+
+		await expect(warm).resolves.toBe(mockData);
+		expect(state.data).toBe(mockData);
+		expect(state.dataPromise).toBeNull();
+	});
+});
+
+describe('ensureData – cancelled read still settling', () => {
+	it('starts a fresh read instead of handing on the cancellation', async () => {
+		const state = makeState(new Map(), 'late-joiner');
+		const reader = new FakeReader();
+
+		const ac = new AbortController();
+		const abandoned = ensureData(state, asReader(reader), undefined, ac.signal);
+		// Assert on it up front: it rejects the moment the abort lands, and an
+		// expectation attached later would first see an unhandled rejection
+		const abandonedRejected = expect(abandoned).rejects.toThrow();
+		await flushMicrotasks();
+
+		ac.abort();
+		// The read is cancelled, but its rejection has not propagated yet — a
+		// subscriber arriving in this window asked for data, not for an abort
+		expect(state.dataPromise).not.toBeNull();
+
+		const p = ensureData(state, asReader(reader), undefined);
+		await flushMicrotasks();
+		expect(reader.calls).toHaveLength(2);
+
+		const mockData = makeMockData();
+		reader.resolveCall(1, mockData);
+		await expect(p).resolves.toBe(mockData);
+		await abandonedRejected;
+
+		// The abandoned read settling later must not clear the fresh one
+		await flushMicrotasks();
+		expect(state.data).toBe(mockData);
 		expect(state.dataPromise).toBeNull();
 	});
 });


### PR DESCRIPTION
### Summary

- When requesting the TileJSON the `ensureData` is removed, because that made handling the abort pipeline unecessarily complex.
- The ensureData is now properly handling cancelled tiles, with join or renew flows.