### PR TITLE
feat: grid bounds and data-hugging boundary polygons

### DIFF
--- a/src/grids/gaussian.ts
+++ b/src/grids/gaussian.ts
@@ -56,6 +56,11 @@ export class GaussianGrid implements GridInterface {
 		];
 	}
 
+	edgeDistanceDeg(lat: number, lon: number): number {
+		const [minLon, minLat, maxLon, maxLat] = this.getBounds();
+		return Math.min(lon - minLon, maxLon - lon, lat - minLat, maxLat - lat);
+	}
+
 	getCenter(): { lng: number; lat: number } {
 		// FIXME: Center hardcoded for now
 		return { lng: 0, lat: 0 };

--- a/src/grids/interface.ts
+++ b/src/grids/interface.ts
@@ -40,6 +40,15 @@ export interface GridInterface {
 	getBoundaryPolygon(): Array<[number, number]>;
 
 	/**
+	 * Approximate distance (in degrees, positive inside) from (lat, lon) to the
+	 * nearest edge of the grid's actual data region. For projected grids this is
+	 * measured in projection space, so the seamless blend zone follows the true
+	 * (curved) domain boundary instead of an axis-aligned lat/lon box. Regular and
+	 * gaussian grids return the distance to their bounds rectangle.
+	 */
+	edgeDistanceDeg(lat: number, lon: number): number;
+
+	/**
 	 * Iterates over grid points, invoking the callback with the flat array index
 	 * and the geographic coordinates for each point.
 	 * When `bounds` is provided, only points within the geographic bounding box

--- a/src/grids/projected.ts
+++ b/src/grids/projected.ts
@@ -268,6 +268,24 @@ export class ProjectionGrid implements GridInterface {
 		return ring;
 	}
 
+	edgeDistanceDeg(lat: number, lon: number): number {
+		// In projection space the grid is an axis-aligned rectangle, so distance to
+		// the nearest edge — measured in grid cells — traces the true curved boundary
+		// when mapped back to lon/lat. Convert that cell distance to an approximate
+		// degree distance using the grid's mean cell size so it stays comparable to
+		// `blendWidthDeg`.
+		const [px, py] = this.projection.forward(lat, lon);
+		const x = (px - this.minX) / this.dx; // fractional column, 0..nx-1 inside
+		const y = (py - this.minY) / this.dy; // fractional row, 0..ny-1 inside
+		const colDist = Math.min(x, this.nx - 1 - x);
+		const rowDist = Math.min(y, this.ny - 1 - y);
+
+		const [minLon, minLat, maxLon, maxLat] = this.getBounds();
+		const degPerCol = (maxLon - minLon) / (this.nx - 1);
+		const degPerRow = (maxLat - minLat) / (this.ny - 1);
+		return Math.min(colDist * degPerCol, rowDist * degPerRow);
+	}
+
 	private getProjectedBorderPoints(): number[][] {
 		const points = [];
 		for (let i = 0; i < this.ny; i++) {

--- a/src/grids/regular.ts
+++ b/src/grids/regular.ts
@@ -247,6 +247,11 @@ export class RegularGrid implements GridInterface {
 		];
 	}
 
+	edgeDistanceDeg(lat: number, lon: number): number {
+		const [minLon, minLat, maxLon, maxLat] = this.bounds;
+		return Math.min(lon - minLon, maxLon - lon, lat - minLat, maxLat - lat);
+	}
+
 	getCenter(): { lng: number; lat: number } {
 		if (!this.center) {
 			this.center = {

--- a/src/tests/boundary.test.ts
+++ b/src/tests/boundary.test.ts
@@ -118,3 +118,31 @@ describe('getBoundaryPolygon', () => {
 		expect(distinctLatsAtExtremeLon.size).toBeGreaterThan(0);
 	});
 });
+
+describe('edgeDistanceDeg', () => {
+	it('is ~0 on the boundary and clearly positive deep inside (projected grid)', () => {
+		const grid = gridOf('ncep_hrrr_conus');
+		for (const [lon, lat] of grid.getBoundaryPolygon()) {
+			expect(Math.abs(grid.edgeDistanceDeg(lat, lon))).toBeLessThan(0.2);
+		}
+		const c = grid.getCenter();
+		expect(grid.edgeDistanceDeg(c.lat, c.lng)).toBeGreaterThan(1);
+	});
+
+	it('follows the curved boundary, not the bounding box', () => {
+		const grid = gridOf('ncep_hrrr_conus');
+		const [minLon, minLat, maxLon, maxLat] = grid.getBounds();
+		const boxDist = (lon: number, lat: number) =>
+			Math.min(lon - minLon, maxLon - lon, lat - minLat, maxLat - lat);
+
+		// A boundary vertex that sits far from every bbox edge lives on the curved
+		// part of the perimeter. The old rectangular blend would see it as deep
+		// inside (large box distance → no blend → hard seam); the projection-aware
+		// distance correctly reports it as on the edge (~0).
+		const onCurve = grid.getBoundaryPolygon().find(([lon, lat]) => boxDist(lon, lat) > 1);
+		expect(onCurve).toBeDefined();
+		const [lon, lat] = onCurve!;
+		expect(boxDist(lon, lat)).toBeGreaterThan(1);
+		expect(grid.edgeDistanceDeg(lat, lon)).toBeLessThan(0.3);
+	});
+});

--- a/src/tests/bounds.test.ts
+++ b/src/tests/bounds.test.ts
@@ -1,4 +1,5 @@
 import {
+	boundsIntersect,
 	checkAgainstBounds,
 	constrainBounds,
 	currentBounds,
@@ -352,6 +353,36 @@ describe('constrainBounds', () => {
 			const clip: Bounds = [-180, -90, 180, 90];
 
 			expect(constrainBounds(bounds, clip)).toEqual([-50, 0, 50, 0]);
+		});
+	});
+
+	describe('boundsIntersect', () => {
+		it('returns true for overlapping boxes', () => {
+			expect(boundsIntersect([0, 0, 10, 10], [5, 5, 15, 15])).toBe(true);
+		});
+
+		it('returns true when one box contains the other', () => {
+			expect(boundsIntersect([-180, -90, 180, 90], [5, 5, 15, 15])).toBe(true);
+		});
+
+		it('returns false when longitudes are disjoint', () => {
+			// e.g. a France domain vs a viewport over Japan
+			expect(boundsIntersect([-5, 40, 10, 55], [120, 30, 150, 45])).toBe(false);
+		});
+
+		it('returns false when latitudes are disjoint', () => {
+			expect(boundsIntersect([0, -80, 10, -60], [0, 60, 10, 80])).toBe(false);
+		});
+
+		it('treats edge-touching boxes as intersecting', () => {
+			expect(boundsIntersect([0, 0, 10, 10], [10, 10, 20, 20])).toBe(true);
+		});
+
+		it('handles a dateline-crossing box (minLon > maxLon)', () => {
+			// Box wraps the antimeridian: [170..180] ∪ [-180..-170].
+			expect(boundsIntersect([170, 0, -170, 10], [175, 5, 178, 8])).toBe(true); // right segment
+			expect(boundsIntersect([170, 0, -170, 10], [-179, 5, -175, 8])).toBe(true); // left segment
+			expect(boundsIntersect([170, 0, -170, 10], [0, 5, 10, 8])).toBe(false); // in the gap
 		});
 	});
 });

--- a/src/utils/bounds.ts
+++ b/src/utils/bounds.ts
@@ -81,6 +81,33 @@ export const boundsIncluded = (innerBounds: Bounds, outerBounds: Bounds): boolea
 	return inMinX >= outMinX && inMinY >= outMinY && inMaxX <= outMaxX && inMaxY <= outMaxY;
 };
 
+/** True when two longitude spans overlap, treating a span with min > max as
+ *  dateline-crossing ([min..180] ∪ [-180..max]). */
+const lonRangesOverlap = (aMin: number, aMax: number, bMin: number, bMax: number): boolean => {
+	const aWraps = aMin > aMax;
+	const bWraps = bMin > bMax;
+	if (!aWraps && !bWraps) return aMin <= bMax && bMin <= aMax;
+	// A wrapping span always includes the antimeridian, so two wrapping spans
+	// necessarily overlap there.
+	if (aWraps && bWraps) return true;
+	// Exactly one wraps: the non-wrapping span overlaps if it reaches either the
+	// [min..180] or the [-180..max] segment of the wrapping one.
+	if (aWraps) return bMax >= aMin || bMin <= aMax;
+	return aMax >= bMin || aMin <= bMax;
+};
+
+/**
+ * True when two lon/lat bounding boxes overlap (share any area). Latitude is a
+ * plain interval test; longitude tolerates dateline-crossing boxes on either
+ * side. Used to decide whether a domain is at least partially inside the map
+ * viewport before loading/blending it.
+ */
+export const boundsIntersect = (a: Bounds, b: Bounds): boolean => {
+	// Latitude never wraps.
+	if (a[1] > b[3] || b[1] > a[3]) return false;
+	return lonRangesOverlap(a[0], a[2], b[0], b[2]);
+};
+
 /*
 Compares domain bounds against bounds limitation set in clippingOptions.
 Returns undefined when the two bounds do not overlap at all.


### PR DESCRIPTION
Groundwork for seamless composites: every grid can now report its geographic
bounds, and boundary polygons hug the actual data rather than the grid box.

- `getBounds()` on the grid interface, implemented for regular, gaussian and
  projected grids
- boundary polygons follow the data edge for NULL-padded reprojected grids,
  with curved east/west sides approximated rather than cut straight
- bounds helpers in `utils/bounds.ts` for intersection tests

Useful on its own — the viewport gate and the border overlay both build on it.

Bottom of a 4-PR stack. Verified: tsc clean, 226 tests pass.
