### PR TITLE
feat: distance to the nearest NaN for edge blending

### DIFF
--- a/src/tests/nan-distance.test.ts
+++ b/src/tests/nan-distance.test.ts
@@ -1,0 +1,23 @@
+import { computeNanDistanceField } from '../utils/nan-distance';
+import { describe, expect, it } from 'vitest';
+
+describe('computeNanDistanceField', () => {
+	it('returns undefined when there is no missing data', () => {
+		expect(computeNanDistanceField(new Float32Array(9).fill(1), 3, 3, 1, 1)).toBeUndefined();
+	});
+
+	it('measures the degree distance to the nearest NaN along a row', () => {
+		// [NaN, 1, 1, 1, 1] with dx=2 → distances 0,2,4,6,8
+		const field = computeNanDistanceField(new Float32Array([NaN, 1, 1, 1, 1]), 5, 1, 2, 1)!;
+		expect(Array.from(field)).toEqual([0, 2, 4, 6, 8]);
+	});
+
+	it('reports 0 at NaN cells and grows away from the NaN boundary', () => {
+		// 5×5 grid, valid only in the centre cell, NaN everywhere else.
+		const values = new Float32Array(25).fill(NaN);
+		values[2 * 5 + 2] = 1;
+		const field = computeNanDistanceField(values, 5, 5, 1, 1)!;
+		expect(field[2 * 5 + 2]).toBeCloseTo(1, 5); // centre is one cell from NaN
+		expect(field[0]).toBe(0); // a NaN cell
+	});
+});

--- a/src/utils/nan-distance.ts
+++ b/src/utils/nan-distance.ts
@@ -1,0 +1,69 @@
+/**
+ * Two-pass chamfer distance transform: for every cell, the approximate distance
+ * (in degrees) to the nearest NaN ("no data") cell.
+ *
+ * Reprojected domains stored on a regular lat/lon grid (e.g. DWD ICON-D2 or
+ * MF AROME France) fill the area around their real shape with NaN. Measuring the
+ * distance to that NaN lets the seamless blend fade across the *real* data
+ * boundary instead of the rectangular grid box.
+ *
+ * Returns `undefined` when the data contains no NaN (nothing to fade against),
+ * so callers can cheaply skip non-padded grids.
+ */
+export const computeNanDistanceField = (
+	values: Float32Array,
+	nx: number,
+	ny: number,
+	dx: number,
+	dy: number
+): Float32Array | undefined => {
+	const n = nx * ny;
+	if (values.length < n) return undefined;
+
+	// Gate: grids without missing data need no field.
+	let hasNan = false;
+	for (let i = 0; i < n; i++) {
+		if (Number.isNaN(values[i])) {
+			hasNan = true;
+			break;
+		}
+	}
+	if (!hasNan) return undefined;
+
+	const hx = Math.abs(dx); // horizontal step in degrees (lon)
+	const hy = Math.abs(dy); // vertical step in degrees (lat)
+	const hd = Math.hypot(hx, hy); // diagonal step
+	const INF = 1e9;
+
+	const dist = new Float32Array(n);
+	for (let i = 0; i < n; i++) dist[i] = Number.isNaN(values[i]) ? 0 : INF;
+
+	// Forward pass (top-left → bottom-right).
+	for (let y = 0; y < ny; y++) {
+		for (let x = 0; x < nx; x++) {
+			const i = y * nx + x;
+			let d = dist[i];
+			if (d === 0) continue;
+			if (x > 0) d = Math.min(d, dist[i - 1] + hx);
+			if (y > 0) d = Math.min(d, dist[i - nx] + hy);
+			if (x > 0 && y > 0) d = Math.min(d, dist[i - nx - 1] + hd);
+			if (x < nx - 1 && y > 0) d = Math.min(d, dist[i - nx + 1] + hd);
+			dist[i] = d;
+		}
+	}
+
+	// Backward pass (bottom-right → top-left).
+	for (let y = ny - 1; y >= 0; y--) {
+		for (let x = nx - 1; x >= 0; x--) {
+			const i = y * nx + x;
+			let d = dist[i];
+			if (x < nx - 1) d = Math.min(d, dist[i + 1] + hx);
+			if (y < ny - 1) d = Math.min(d, dist[i + nx] + hy);
+			if (x < nx - 1 && y < ny - 1) d = Math.min(d, dist[i + nx + 1] + hd);
+			if (x > 0 && y < ny - 1) d = Math.min(d, dist[i + nx - 1] + hd);
+			dist[i] = d;
+		}
+	}
+
+	return dist;
+};


### PR DESCRIPTION
Computes, for each grid point, the distance to the nearest NaN. That field is
what the seamless blend weights are derived from: a value close to a model's
data edge contributes less than one deep inside it, so composites cross domain
boundaries without a visible seam rather than switching abruptly.

Consumed by `seamless-sampling.ts`, which caches one field per layer and turns
it into a smooth-step weight — 1 deep inside the layer, falling off toward the
edge. Only regular grids get a field today (it needs `dx`/`dy`); gaussian and
projected layers fall back to the unweighted path.

Standalone utility plus its tests. Verified: tsc clean, 229 tests pass.
