### PR TITLE
feat: seamless domain model, sampling and protocol wiring

### DIFF
--- a/src/domain-helpers.ts
+++ b/src/domain-helpers.ts
@@ -1,0 +1,49 @@
+/**
+ * Helpers for working with `AnyDomain` values — in particular for resolving the
+ * concrete grid-based `Domain` that backs a zoom-adaptive `SeamlessDomain`.
+ *
+ * These were previously re-implemented inline in several consumers (and inside
+ * this library); they are collected here and exported so both the protocol
+ * internals and downstream apps share a single source of truth.
+ */
+import type { AnyDomain, Domain, SeamlessDomain } from './types';
+
+/** Returns true when `domain` is a `SeamlessDomain` (composite, zoom-adaptive). */
+export const isSeamlessDomain = (domain: AnyDomain): domain is SeamlessDomain => 'layers' in domain;
+
+/**
+ * Looks up the concrete (non-seamless) `Domain` whose `value` matches `domainValue`.
+ * Returns `undefined` when no matching concrete domain exists.
+ */
+export const resolveConcreteDomain = (
+	domainValue: string,
+	domainOptions: AnyDomain[]
+): Domain | undefined =>
+	domainOptions.find((d) => d.value === domainValue && !isSeamlessDomain(d)) as Domain | undefined;
+
+/**
+ * Resolves the concrete `Domain` that backs `domain`:
+ *  - for a `SeamlessDomain`, the concrete domain of its global fallback layer;
+ *  - for a regular `Domain`, the domain itself.
+ *
+ * Returns `undefined` when a seamless domain's backing domain is not present in
+ * `domainOptions`.
+ */
+export const getFallbackDomain = (
+	domain: AnyDomain,
+	domainOptions: AnyDomain[]
+): Domain | undefined =>
+	isSeamlessDomain(domain)
+		? resolveConcreteDomain(getFallbackDomainValue(domain), domainOptions)
+		: domain;
+
+/**
+ * Returns the `value` of the concrete domain that should back `domain`:
+ *  - for a `SeamlessDomain`, the last layer's `domainValue` (the global fallback);
+ *  - for a regular `Domain`, its own `value`.
+ *
+ * Useful when a seamless domain needs to be mapped to a real server path or grid,
+ * e.g. for metadata fetches and initial map positioning.
+ */
+export const getFallbackDomainValue = (domain: AnyDomain): string =>
+	isSeamlessDomain(domain) ? domain.layers[domain.layers.length - 1].domainValue : domain.value;

--- a/src/domains.ts
+++ b/src/domains.ts
@@ -1,4 +1,4 @@
-import type { Domain } from './types';
+import type { AnyDomain } from './types';
 
 export const domainGroups = [
 	// { value: 'bom', label: 'BOM Australia' },
@@ -21,7 +21,204 @@ export const domainGroups = [
 	{ value: 'ukmo', label: 'UKMO' }
 ];
 
-export const domainOptions: Array<Domain> = [
+export const domainOptions: Array<AnyDomain> = [
+	// -------------------------------------------------------------------------
+	// Seamless composite domains
+	// -------------------------------------------------------------------------
+
+	/**
+	 * DWD ICON Seamless
+	 *
+	 * Automatically selects the best-available DWD model for the current zoom
+	 * level and blends values near domain boundaries:
+	 *   zoom 0+  → dwd_icon   (global, 0.125°)
+	 *   zoom 2+  → dwd_icon_eu (Europe, 0.0625°)
+	 *   zoom 3+  → dwd_icon_d2 (Germany, 0.02°)
+	 *
+	 * The URL format is identical to a regular domain – just replace the domain
+	 * name segment with 'dwd_icon_seamless':
+	 *   om://…/data_spatial/dwd_icon_seamless/…/…om?variable=…
+	 */
+	{
+		type: 'seamless',
+		value: 'dwd_icon_seamless',
+		label: 'DWD ICON Seamless',
+		// All constituent DWD ICON domains share the same time resolution and
+		// model-run cadence, so we surface them here so consuming code can treat
+		// dwd_icon_seamless uniformly alongside regular domains.
+		time_interval: 'hourly',
+		model_interval: '3_hourly',
+		layers: [
+			{ domainValue: 'dwd_icon_d2', minZoom: 3, blendWidthDeg: 0, maxForecastHours: 48 },
+			{ domainValue: 'dwd_icon_eu', minZoom: 2, blendWidthDeg: 0, maxForecastHours: 120 },
+			{ domainValue: 'dwd_icon', minZoom: 0, blendWidthDeg: 0 }
+		]
+	},
+
+	/**
+	 * NCEP GFS + HRRR Seamless
+	 *
+	 * Automatically selects the best NCEP model for the current zoom level:
+	 *   zoom 0+  → ncep_gfs025     (global, 0.25°)
+	 *   zoom 2+  → ncep_hrrr_conus (CONUS, ~3 km, Lambert Conformal)
+	 */
+	{
+		type: 'seamless',
+		value: 'ncep_gfs_seamless',
+		label: 'GFS Seamless',
+		time_interval: 'hourly',
+		model_interval: 'hourly',
+		layers: [
+			{ domainValue: 'ncep_hrrr_conus', minZoom: 2, blendWidthDeg: 0, maxForecastHours: 48 },
+			{ domainValue: 'ncep_gfs025', minZoom: 0, blendWidthDeg: 0 }
+		]
+	},
+
+	/**
+	 * Météo-France Seamless
+	 *
+	 * Automatically selects the best MF model for the current zoom level:
+	 *   zoom 0+  → meteofrance_arpege_world025   (global, 0.25°)
+	 *   zoom 2+  → meteofrance_arpege_europe      (Europe, 0.1°)
+	 *   zoom 4+  → meteofrance_arome_france0025   (France, 0.025°)
+	 */
+	{
+		type: 'seamless',
+		value: 'meteofrance_seamless',
+		label: 'MF Seamless',
+		time_interval: 'hourly',
+		model_interval: '3_hourly',
+		layers: [
+			{
+				domainValue: 'meteofrance_arome_france0025',
+				minZoom: 3,
+				blendWidthDeg: 0,
+				maxForecastHours: 51
+			},
+			{
+				domainValue: 'meteofrance_arpege_europe',
+				minZoom: 2,
+				blendWidthDeg: 0,
+				maxForecastHours: 102
+			},
+			{ domainValue: 'meteofrance_arpege_world025', minZoom: 0, blendWidthDeg: 0 }
+		]
+	},
+
+	/**
+	 * GEM Canada Seamless
+	 *
+	 * Automatically selects the best GEM model for the current zoom level:
+	 *   zoom 0+  → cmc_gem_gdps_15km  (global, 0.15°)
+	 *   zoom 2+  → cmc_gem_rdps_10km  (North America, ~10 km, Rotated LatLon)
+	 *   zoom 3+  → cmc_gem_hrdps (Canada, ~2.5 km, Rotated LatLon)
+	 *   zoom 4+  → cmc_gem_hrdps_west (Canada, ~1 km, Rotated LatLon)
+	 */
+	{
+		type: 'seamless',
+		value: 'cmc_gem_seamless',
+		label: 'GEM Seamless',
+		time_interval: 'hourly',
+		model_interval: '6_hourly',
+		layers: [
+			{ domainValue: 'cmc_gem_hrdps_west', minZoom: 4, blendWidthDeg: 0, maxForecastHours: 48 },
+			{ domainValue: 'cmc_gem_hrdps', minZoom: 3, blendWidthDeg: 0, maxForecastHours: 48 },
+			{ domainValue: 'cmc_gem_rdps_10km', minZoom: 2, blendWidthDeg: 0, maxForecastHours: 84 },
+			{ domainValue: 'cmc_gem_gdps_15km', minZoom: 0, blendWidthDeg: 0 }
+		]
+	},
+
+	/**
+	 * JMA Seamless
+	 *
+	 * Automatically selects the best JMA model for the current zoom level:
+	 *   zoom 0+  → jma_gsm  (global, 0.5°)
+	 *   zoom 3+  → jma_msm  (Japan, 0.0625°/0.05°)
+	 */
+	{
+		type: 'seamless',
+		value: 'jma_seamless',
+		label: 'JMA Seamless',
+		time_interval: 'hourly',
+		model_interval: '3_hourly',
+		layers: [
+			{ domainValue: 'jma_msm', minZoom: 3, blendWidthDeg: 0, maxForecastHours: 78 },
+			{ domainValue: 'jma_gsm', minZoom: 0, blendWidthDeg: 0 }
+		]
+	},
+
+	/**
+	 * UK Met Office Seamless
+	 *
+	 * Automatically selects the best UKMO model for the current zoom level:
+	 *   zoom 0+  → ukmo_global_deterministic_10km  (global, ~10 km)
+	 *   zoom 3+  → ukmo_uk_deterministic_2km        (UK, 2 km, LAEA)
+	 */
+	{
+		type: 'seamless',
+		value: 'ukmo_seamless',
+		label: 'UKMO Seamless',
+		time_interval: 'hourly',
+		model_interval: '3_hourly',
+		layers: [
+			{
+				domainValue: 'ukmo_uk_deterministic_2km',
+				minZoom: 3,
+				blendWidthDeg: 0,
+				maxForecastHours: 126
+			},
+			{ domainValue: 'ukmo_global_deterministic_10km', minZoom: 0, blendWidthDeg: 0 }
+		]
+	},
+
+	/**
+	 * KNMI Seamless
+	 *
+	 * Automatically selects the best KNMI model for the current zoom level:
+	 *   zoom 0+  → knmi_harmonie_arome_europe       (Europe, ~2.5 km, Rotated LatLon)
+	 *   zoom 3+  → knmi_harmonie_arome_netherlands  (Netherlands, 0.029°/0.018°)
+	 */
+	{
+		type: 'seamless',
+		value: 'knmi_seamless',
+		label: 'KNMI Seamless',
+		time_interval: 'hourly',
+		model_interval: '3_hourly',
+		layers: [
+			{
+				domainValue: 'knmi_harmonie_arome_netherlands',
+				minZoom: 3,
+				blendWidthDeg: 0,
+				maxForecastHours: 48
+			},
+			{ domainValue: 'knmi_harmonie_arome_europe', minZoom: 0, blendWidthDeg: 0 }
+		]
+	},
+
+	/**
+	 * CHMI Seamless
+	 *
+	 * Automatically selects the best CHMI model for the current zoom level:
+	 *   zoom 0+  → chmi_aladin_central_europe_2km       (Europe, ~2.5 km, Rotated LatLon)
+	 *   zoom 3+  → chmi_aladin_cz_1km  (Czech Republic, 0.029°/0.018°)
+	 */
+	{
+		type: 'seamless',
+		value: 'chmi_seamless',
+		label: 'Aladin Seamless',
+		time_interval: 'hourly',
+		model_interval: '3_hourly',
+		layers: [
+			{
+				domainValue: 'chmi_aladin_cz_1km',
+				minZoom: 3,
+				blendWidthDeg: 0,
+				maxForecastHours: 48
+			},
+			{ domainValue: 'chmi_aladin_central_europe_2km', minZoom: 0, blendWidthDeg: 0 }
+		]
+	},
+
 	// BOM
 	// {
 	// 	value: 'bom_access_global',
@@ -1284,6 +1481,7 @@ export const domainOptions: Array<Domain> = [
 			}
 		},
 		time_interval: 'hourly',
-		model_interval: '3_hourly'
+		model_interval: '3_hourly',
+		windUVComponents: false
 	}
 ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,12 @@ export { omProtocol } from './om-protocol';
 // Functions
 
 export {
+	isSeamlessDomain,
+	getFallbackDomainValue,
+	resolveConcreteDomain,
+	getFallbackDomain
+} from './domain-helpers';
+export {
 	getValueFromLatLong,
 	clearBlockCache,
 	clearBackends,
@@ -18,6 +24,7 @@ export { getColor, getColorScale } from './utils/styling';
 // Classes
 
 export { GridFactory } from './grids/index';
+export { WeatherMapLayerFileReader } from './om-file-reader';
 
 // Objects / Constants
 
@@ -37,6 +44,7 @@ export { addOpenLayersProtocolSupport } from './adapters/openlayers';
 // Types
 
 export type {
+	AnyDomain,
 	ClippingOptions,
 	Data,
 	Domain,
@@ -48,7 +56,7 @@ export type {
 	InterpolationMethod,
 	OmProtocolSettings,
 	OmUrlState,
-	RenderableColorScale
+	RenderableColorScale,
+	SeamlessDomain,
+	SeamlessLayer
 } from './types';
-
-export type { WeatherMapLayerFileReader } from './om-file-reader';

--- a/src/om-protocol-seamless.ts
+++ b/src/om-protocol-seamless.ts
@@ -1,0 +1,310 @@
+/**
+ * Seamless domain protocol handler.
+ *
+ * Extracted from om-protocol.ts to keep the core protocol file clean.
+ * Contains all logic specific to SeamlessDomain composite domains.
+ */
+import { type GetResourceResponse, type RequestParameters } from 'maplibre-gl';
+
+import { boundsIntersect, constrainBounds } from './utils/bounds';
+
+import { resolveConcreteDomain } from './domain-helpers';
+import { GridFactory } from './grids/index';
+import { DEFAULT_MAX_STATES_WITH_DATA, ensureData, getOrCreateState } from './om-protocol-state';
+import { capitalize } from './utils';
+import { workerPool } from './worker-pool-instance';
+
+import type {
+	Bounds,
+	Data,
+	DataIdentityOptions,
+	DimensionRange,
+	OmProtocolInstance,
+	OmProtocolSettings,
+	ParsedRequest,
+	SeamlessDomain,
+	SeamlessLayerRenderData,
+	TileJSON,
+	TilePromise,
+	TileResponse,
+	TileResult
+} from './types';
+
+export { isSeamlessDomain } from './domain-helpers';
+
+/**
+ * Parse the model-run → valid-time lead in hours from an OM file URL.
+ *
+ * Expected URL segment: …/YYYY/MM/DD/HHmmZ/YYYY-MM-DDTHHmm.om
+ * Returns `undefined` when the URL does not match that structure.
+ */
+const parseLeadTimeHours = (url: string): number | undefined => {
+	const m = url.match(
+		/\/(\d{4})\/(\d{2})\/(\d{2})\/(\d{2})(\d{2})Z\/(\d{4}-\d{2}-\d{2})T(\d{2})(\d{2})\.om/
+	);
+	if (!m) return undefined;
+	const [, yr, mo, dy, rh, rm, date, vh, vm] = m;
+	const modelRun = Date.UTC(+yr, +mo - 1, +dy, +rh, +rm);
+	const validTime = Date.UTC(
+		+date.slice(0, 4),
+		+date.slice(5, 7) - 1,
+		+date.slice(8, 10),
+		+vh,
+		+vm
+	);
+	return (validTime - modelRun) / (1000 * 60 * 60);
+};
+
+// ─── Tile response helpers ─────────────────────────────────────────────────────
+
+const makeTileAbortedResponse = (): TileResult => ({ data: undefined, cancelled: true });
+const makeEmptyVectorLayerResponse = (): TileResult => ({
+	data: new ArrayBuffer(0),
+	cancelled: false
+});
+
+/**
+ * Like `requestTile` in om-protocol.ts but also passes `seamlessLayers` to the
+ * worker so it can perform per-pixel blending across domain boundaries.
+ */
+const requestTileSeamless = async (
+	url: string,
+	request: ParsedRequest,
+	primaryData: Data,
+	primaryRanges: DimensionRange[],
+	seamlessLayers: SeamlessLayerRenderData[],
+	type: 'image' | 'arrayBuffer',
+	signal?: AbortSignal
+): TilePromise => {
+	if (!request.tileIndex) {
+		throw new Error('Tile coordinates required for seamless tile request');
+	}
+
+	if (signal?.aborted) {
+		return makeTileAbortedResponse();
+	}
+
+	const key = `${type}:${url}`;
+	const tileType = `get${capitalize(type)}` as 'getImage' | 'getArrayBuffer';
+
+	if (tileType === 'getArrayBuffer') {
+		if (
+			!(request.renderOptions.drawArrows && primaryData.directions !== undefined) &&
+			!request.renderOptions.drawContours &&
+			!request.renderOptions.drawGrid
+		) {
+			return makeEmptyVectorLayerResponse();
+		}
+	}
+
+	return workerPool.requestTile({
+		type: tileType,
+		key,
+		tileIndex: request.tileIndex,
+		// Primary layer data used as fallback for vector tile paths
+		data: primaryData,
+		ranges: primaryRanges,
+		dataOptions: request.dataOptions,
+		renderOptions: request.renderOptions,
+		clippingOptions: request.clippingOptions,
+		seamlessLayers,
+		signal
+	});
+};
+
+// ─── Main export ──────────────────────────────────────────────────────────────
+
+/**
+ * Handles a request whose domain is a SeamlessDomain:
+ *  - Picks which concrete layers are active for the current zoom level
+ *  - Skips layers whose `maxForecastHours` is exceeded by the URL's lead time,
+ *    silently falling back to coarser layers instead of issuing a 404 request
+ *  - Loads each layer's data from its own URL (substituting the domain name)
+ *  - For image tiles: passes all layer data to the worker for per-pixel blending
+ *  - For TileJSON: returns the bounds of the global (last) layer immediately,
+ *    without blocking on data loading
+ */
+export const handleSeamlessRequest = async (
+	params: RequestParameters,
+	url: string,
+	request: ParsedRequest,
+	seamlessDomain: SeamlessDomain,
+	instance: OmProtocolInstance,
+	settings: OmProtocolSettings,
+	signal: AbortSignal
+): Promise<GetResourceResponse<TileJSON | TileResponse | null>> => {
+	if (signal.aborted) return { data: null };
+
+	const z = request.tileIndex?.z ?? 0;
+
+	// Layers are ordered finest-first; keep those whose minZoom <= current zoom
+	const activeLayers = seamlessDomain.layers.filter((l) => l.minZoom <= z);
+
+	if (activeLayers.length === 0) return { data: null };
+
+	// TileJSON: return bounds from the global (last) layer immediately —
+	// no data load needed; bounds are computable from the domain grid definition.
+	if (params.type === 'json') {
+		const lastLayer = activeLayers[activeLayers.length - 1];
+		const globalDomain = resolveConcreteDomain(lastLayer.domainValue, settings.domainOptions);
+		if (!globalDomain) return { data: null };
+
+		const fullGrid = GridFactory.create(globalDomain.grid, null);
+		let bounds: Bounds = fullGrid.getBounds() as Bounds;
+		if (request.clippingOptions?.bounds) {
+			bounds = constrainBounds(bounds, request.clippingOptions.bounds) ?? bounds;
+		}
+		return {
+			data: {
+				tilejson: '3.0.0' as const,
+				tiles: [params.url + '/{z}/{x}/{y}'],
+				attribution: '<a href="https://open-meteo.com/en/licence#maps">© Open-Meteo</a>',
+				minzoom: 0,
+				maxzoom: 12,
+				bounds
+			}
+		};
+	}
+
+	if (params.type !== 'image' && params.type !== 'arrayBuffer') {
+		throw new Error(`Unsupported request type '${params.type}'`);
+	}
+
+	if (!request.tileIndex) {
+		throw new Error(`Tile coordinates required for ${params.type} request`);
+	}
+
+	// The global fallback (last layer) covers the whole world and must always be
+	// loaded — it is the only layer guaranteed to produce a value everywhere — so
+	// it is exempt from the viewport gate below.
+	const globalLayer = seamlessDomain.layers[seamlessDomain.layers.length - 1];
+	const viewportBounds = request.dataOptions.bounds;
+
+	// Load data for every active layer in parallel — reads are atomic per call, so
+	// concurrent loads are safe. Promise.all preserves the finest-first layer
+	// order; gated or failed layers resolve to null and are filtered out. After
+	// the first load the data is cached in state.data, so subsequent tile requests
+	// for the same time-step return immediately.
+	const layerResults = await Promise.all(
+		activeLayers.map(async (layer): Promise<SeamlessLayerRenderData | null> => {
+			if (signal.aborted) return null;
+
+			const concreteDomain = resolveConcreteDomain(layer.domainValue, settings.domainOptions);
+
+			if (!concreteDomain) {
+				console.warn(`[seamless] Domain not found: ${layer.domainValue}`);
+				return null;
+			}
+
+			// Full geographic bounds of this domain (not viewport-cropped) — needed both
+			// for the viewport gate here and for the blend math passed to the worker.
+			const fullGrid = GridFactory.create(concreteDomain.grid, null);
+			const domainBounds = fullGrid.getBounds() as Bounds;
+
+			// Viewport gate: a local (non-global) layer that does not even partially
+			// overlap the current map viewport contributes nothing to any visible tile,
+			// so skip loading and blending it entirely. This keeps composite domains that
+			// stack many regional models (e.g. om_global_seamless) cheap: only the models
+			// actually on screen are fetched and blended.
+			if (
+				layer !== globalLayer &&
+				viewportBounds &&
+				!boundsIntersect(domainBounds, viewportBounds)
+			) {
+				return null;
+			}
+
+			// Derive the concrete URL by substituting the seamless domain name
+			const concreteBaseUrl = request.baseUrl.replace(
+				`/data_spatial/${seamlessDomain.value}/`,
+				`/data_spatial/${concreteDomain.value}/`
+			);
+			const concreteKey = request.fileAndVariableKey.replace(
+				`/data_spatial/${seamlessDomain.value}/`,
+				`/data_spatial/${concreteDomain.value}/`
+			);
+
+			// Guard against 404 network errors: if the domain advertises a maximum forecast
+			// horizon and the requested timestep is beyond it, skip this layer entirely and
+			// fall through to the next coarser layer.  This prevents the browser from issuing
+			// a request that the server will reject with a 404 (which browsers log as a CORS
+			// error when the 404 response omits Access-Control-Allow-Origin).
+			if (layer.maxForecastHours !== undefined) {
+				const leadTime = parseLeadTimeHours(concreteBaseUrl);
+				if (leadTime !== undefined && leadTime > layer.maxForecastHours) {
+					return null;
+				}
+			}
+
+			const concreteDataOptions: DataIdentityOptions = {
+				domain: concreteDomain,
+				variable: request.dataOptions.variable,
+				bounds: request.dataOptions.bounds
+			};
+
+			const state = getOrCreateState(
+				instance.stateByKey,
+				concreteKey,
+				concreteDataOptions,
+				concreteBaseUrl,
+				// One composite costs a state per active layer, so the cap the
+				// caller expressed in variables has to be multiplied by them.
+				// Left at the plain cap, every tile request would evict the
+				// sub-layers the next one still needs and re-read them.
+				(settings.maxStatesWithData ?? DEFAULT_MAX_STATES_WITH_DATA) * activeLayers.length
+			);
+
+			let data: Data;
+			try {
+				// Run the same postReadCallback the regular path uses. ensureData
+				// short-circuits on state.data, so it fires once per real sub-layer load
+				// (not per tile), letting consumers warm caches / transform values
+				// (e.g. the pressure_msl unit fix) for seamless composites too.
+				data = await ensureData(state, instance.omFileReader, settings.postReadCallback, signal);
+			} catch {
+				return null;
+			}
+
+			return {
+				domain: concreteDomain,
+				data,
+				ranges: state.ranges,
+				domainBounds,
+				blendWidthDeg: layer.blendWidthDeg,
+				// Only blending layers need a NaN-distance field. Key it by the data's
+				// URL + ranges so the worker computes it once per timestep/viewport.
+				nanFieldKey:
+					layer.blendWidthDeg > 0
+						? `${concreteKey}@${state.ranges.map((r) => `${r.start}-${r.end}`).join(',')}`
+						: undefined
+			};
+		})
+	);
+	const seamlessLayers = layerResults.filter(
+		(layer): layer is SeamlessLayerRenderData => layer !== null
+	);
+
+	if (seamlessLayers.length === 0) return { data: null };
+
+	// Use the finest (first) layer as the primary data source for vector tiles
+	const primaryLayer = seamlessLayers[0];
+	const primaryRequest: ParsedRequest = {
+		...request,
+		dataOptions: { ...request.dataOptions, domain: primaryLayer.domain }
+	};
+
+	const tileResult = await requestTileSeamless(
+		url,
+		primaryRequest,
+		primaryLayer.data,
+		primaryLayer.ranges,
+		seamlessLayers,
+		params.type,
+		signal
+	);
+
+	if (tileResult.cancelled || !tileResult.data) {
+		return { data: null };
+	}
+	return { data: tileResult.data };
+};

--- a/src/om-protocol-state.ts
+++ b/src/om-protocol-state.ts
@@ -2,16 +2,17 @@ import { boundsIncluded, constrainBounds } from './utils/bounds';
 import { DEFAULT_INTERPOLATION, VALID_INTERPOLATIONS } from './utils/constants';
 import { normalizeLon } from './utils/math';
 import { parseUrlComponents } from './utils/parse-url';
+import { normalizeUrl } from './utils/parse-url';
 
 import { GridFactory } from './grids';
 import { WeatherMapLayerFileReader } from './om-file-reader';
-import { normalizeUrl } from './om-protocol';
 
 import type {
 	Bounds,
 	Data,
 	DataIdentityOptions,
 	DimensionRange,
+	Domain,
 	GridData,
 	InterpolationMethod,
 	OmProtocolInstance,
@@ -108,7 +109,7 @@ export const getOrCreateState = (
 		// else we need to create a new state
 	}
 
-	const ranges = getRanges(dataOptions.domain.grid, dataOptions.bounds);
+	const ranges = getRanges((dataOptions.domain as Domain).grid, dataOptions.bounds);
 	const state: OmUrlState = {
 		dataOptions,
 		ranges,
@@ -228,7 +229,7 @@ export const getValueFromLatLong = async (
 		return { value: NaN };
 	}
 
-	const grid = GridFactory.create(state.dataOptions.domain.grid, state.ranges);
+	const grid = GridFactory.create((state.dataOptions.domain as Domain).grid, state.ranges);
 	const lonNormalized = normalizeLon(lon);
 	// Sample with the same interpolation the tiles are rendered with (encoded in
 	// the URL) so the popup value matches the pixel under the cursor.

--- a/src/om-protocol.ts
+++ b/src/om-protocol.ts
@@ -3,19 +3,20 @@ import { type GetResourceResponse, type RequestParameters } from 'maplibre-gl';
 import { constrainBounds } from './utils/bounds';
 import { type ResolvedClippingOptions } from './utils/clipping';
 import { defaultResolveRequest, parseRequest } from './utils/parse-request';
-import { parseMetaJson } from './utils/parse-url';
+import { normalizeUrl } from './utils/parse-url';
 import { COLOR_SCALES_WITH_ALIASES as defaultColorScales } from './utils/styling';
 
 import { domainOptions as defaultDomainOptions } from './domains';
 import { GridFactory } from './grids/index';
 import { defaultFileReaderConfig } from './om-file-reader';
+import { handleSeamlessRequest, isSeamlessDomain } from './om-protocol-seamless';
 import { ensureData, getOrCreateState, getProtocolInstance } from './om-protocol-state';
 import { capitalize } from './utils';
-import { WorkerPool } from './worker-pool';
+import { workerPool } from './worker-pool-instance';
 
 import type {
 	Data,
-	DataIdentityOptions,
+	Domain,
 	OmProtocolSettings,
 	OmUrlState,
 	ParsedRequest,
@@ -24,8 +25,6 @@ import type {
 	TileResponse,
 	TileResult
 } from './types';
-
-const workerPool = new WorkerPool();
 
 export const defaultOmProtocolSettings: OmProtocolSettings = {
 	// static
@@ -54,8 +53,21 @@ export const omProtocol = async (
 
 	const instance = getProtocolInstance(settings);
 
-	const url = await normalizeUrl(params.url);
+	const url = await normalizeUrl(params.url, settings.domainOptions);
 	const request = parseRequest(url, settings);
+
+	// Route seamless composite domains to the dedicated handler
+	if (isSeamlessDomain(request.dataOptions.domain)) {
+		return handleSeamlessRequest(
+			params,
+			url,
+			request,
+			request.dataOptions.domain,
+			instance,
+			settings,
+			signal
+		);
+	}
 
 	const state = getOrCreateState(
 		instance.stateByKey,
@@ -80,7 +92,11 @@ export const omProtocol = async (
 			// Errors surface on the awaited tile requests; ignore here.
 		});
 		return {
-			data: await getTilejson(params.url, request.dataOptions, request.clippingOptions)
+			data: await getTilejson(
+				params.url,
+				request.dataOptions.domain as Domain,
+				request.clippingOptions
+			)
 		};
 	}
 
@@ -102,14 +118,6 @@ export const omProtocol = async (
 	} else {
 		return { data: tileResult.data };
 	}
-};
-
-export const normalizeUrl = async (url: string): Promise<string> => {
-	let normalized = url;
-	if (url.includes('.json')) {
-		normalized = await parseMetaJson(normalized);
-	}
-	return normalized;
 };
 
 const makeTileAbortedResponse = (): TileResult => {
@@ -164,11 +172,11 @@ const requestTile = async (
 
 const getTilejson = async (
 	fullUrl: string,
-	dataOptions: DataIdentityOptions,
+	domain: Domain,
 	clippingOptions?: ResolvedClippingOptions
 ): Promise<TileJSON> => {
 	// We initialize the grid with the ranges set to null, because we want to find out the maximum bounds of this grid
-	const grid = GridFactory.create(dataOptions.domain.grid, null);
+	const grid = GridFactory.create(domain.grid, null);
 	let bounds;
 	if (clippingOptions && clippingOptions.bounds) {
 		bounds = constrainBounds(grid.getBounds(), clippingOptions.bounds) ?? grid.getBounds();

--- a/src/tests/bench-worker.ts
+++ b/src/tests/bench-worker.ts
@@ -64,30 +64,26 @@ const renderVector = (job: BenchRenderJob): void => {
 
 	const pbf = new PbfWriter();
 	if (job.mode === 'contours') {
+		const sampleValue = (lat: number, lon: number) =>
+			grid.getInterpolatedValue(job.values, lat, lon, job.method);
 		generateContours(
 			pbf,
-			job.values,
-			grid,
+			sampleValue,
 			job.x,
 			job.y,
 			job.z,
 			job.tileSize,
 			job.intervals ?? [],
-			undefined,
-			job.method
+			undefined
 		);
 	} else {
-		generateArrows(
-			pbf,
-			job.values,
-			job.directions!,
-			grid,
-			job.x,
-			job.y,
-			job.z,
-			undefined,
-			job.method
-		);
+		// Same sampler shape as src/worker.ts: magnitude with the selected
+		// method, direction linear.
+		const sampleVector = (lat: number, lon: number) => ({
+			value: grid.getInterpolatedValue(job.values, lat, lon, job.method),
+			direction: grid.getLinearInterpolatedValue(job.directions!, lat, lon)
+		});
+		generateArrows(pbf, sampleVector, job.x, job.y, job.z, undefined);
 	}
 	pbf.finish();
 };

--- a/src/tests/grids.test.ts
+++ b/src/tests/grids.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, test } from 'vitest';
 import type {
 	AnyProjectionGridData,
 	DimensionRange,
+	Domain,
 	InterpolationMethod,
 	LCCProjectionData,
 	ProjectionGridFromGeographicOrigin,
@@ -14,8 +15,9 @@ import type {
 	RotatedLatLonProjectionData
 } from '../types';
 
-const dmiDomain = domainOptions.find((d) => d.value === 'dmi_harmonie_arome_europe');
-const knmiDomain = domainOptions.find((d) => d.value === 'knmi_harmonie_arome_europe');
+// Both are concrete (non-seamless) domains, so they always carry a grid.
+const dmiDomain = domainOptions.find((d) => d.value === 'dmi_harmonie_arome_europe') as Domain;
+const knmiDomain = domainOptions.find((d) => d.value === 'knmi_harmonie_arome_europe') as Domain;
 
 test('Test LambertConformalConicProjection for DMI', () => {
 	const projectedGrid = dmiDomain?.grid as AnyProjectionGridData;

--- a/src/tests/seamless-sampling.test.ts
+++ b/src/tests/seamless-sampling.test.ts
@@ -1,0 +1,245 @@
+import { GridFactory } from '../grids/index';
+import type { GridInterface } from '../grids/interface';
+import { type GridPointSource, generateGridPoints } from '../utils/grid-points';
+import { sampleBlendedValue, sampleBlendedVector } from '../utils/seamless-sampling';
+import { VectorTile } from '@mapbox/vector-tile';
+import { PbfReader, PbfWriter } from 'pbf';
+import { describe, expect, it } from 'vitest';
+
+import type { Bounds, Domain, GridData, SeamlessLayerRenderData } from '../types';
+
+// --- Test doubles -----------------------------------------------------------
+
+type Coverage = (lat: number, lon: number) => boolean;
+
+/**
+ * Minimal GridInterface returning `speed` for the values array and `dir` for the
+ * directions array, or NaN where `covers` is false (point outside the domain).
+ */
+const fakeGrid = (
+	speed: number,
+	dir: number,
+	dirsRef: Float32Array | undefined,
+	covers: Coverage,
+	bounds: Bounds
+): GridInterface => {
+	const sample = (arr: Float32Array, lat: number, lon: number) =>
+		covers(lat, lon) ? (dirsRef && arr === dirsRef ? dir : speed) : NaN;
+	return {
+		getLinearInterpolatedValue: sample,
+		getLinearInterpolatedDirection: sample,
+		getInterpolatedValue: sample,
+		edgeDistanceDeg: (lat: number, lon: number) =>
+			Math.min(lon - bounds[0], bounds[2] - lon, lat - bounds[1], bounds[3] - lat)
+	} as unknown as GridInterface;
+};
+
+const fakeLayer = (
+	values: Float32Array,
+	directions: Float32Array | undefined,
+	domainBounds: Bounds,
+	blendWidthDeg: number
+): SeamlessLayerRenderData =>
+	({
+		domain: {} as Domain,
+		data: { values, directions },
+		ranges: [],
+		domainBounds,
+		blendWidthDeg
+	}) as SeamlessLayerRenderData;
+
+const FINE_BOUNDS: Bounds = [-10, -10, 10, 10];
+const WORLD_BOUNDS: Bounds = [-180, -90, 180, 90];
+const insideFine: Coverage = (lat, lon) => Math.abs(lat) <= 10 && Math.abs(lon) <= 10;
+const everywhere: Coverage = () => true;
+
+// ---------------------------------------------------------------------------
+
+describe('sampleBlendedValue', () => {
+	const fineVals = new Float32Array([100]);
+	const coarseVals = new Float32Array([50]);
+	const grids = [
+		fakeGrid(100, 0, undefined, insideFine, FINE_BOUNDS),
+		fakeGrid(50, 0, undefined, everywhere, WORLD_BOUNDS)
+	];
+	const layers = [
+		fakeLayer(fineVals, undefined, FINE_BOUNDS, 2),
+		fakeLayer(coarseVals, undefined, WORLD_BOUNDS, 0)
+	];
+	const sample = sampleBlendedValue(grids, layers);
+
+	it('returns the fine value deep inside the fine domain', () => {
+		expect(sample(0, 0)).toBe(100);
+	});
+
+	it('falls through to the coarse domain beyond the fine footprint (fluent)', () => {
+		// Previously the vector path only used the finest layer, so this point had no data.
+		expect(sample(0, 30)).toBe(50);
+	});
+
+	it('smooth-step blends across the edge zone', () => {
+		// At lon 9 the nearest edge distance is (10-9)/2 = 0.5 → smooth-step weight 0.5.
+		expect(sample(0, 9)).toBeCloseTo(75, 6);
+	});
+});
+
+describe('sampleBlendedVector', () => {
+	const fineVals = new Float32Array([10]);
+	const fineDirs = new Float32Array([0]); // north
+	const coarseVals = new Float32Array([10]);
+	const coarseDirs = new Float32Array([90]); // east
+	const grids = [
+		fakeGrid(10, 0, fineDirs, insideFine, FINE_BOUNDS),
+		fakeGrid(10, 90, coarseDirs, everywhere, WORLD_BOUNDS)
+	];
+	const layers = [
+		fakeLayer(fineVals, fineDirs, FINE_BOUNDS, 2),
+		fakeLayer(coarseVals, coarseDirs, WORLD_BOUNDS, 0)
+	];
+	const sample = sampleBlendedVector(grids, layers);
+
+	it('returns the fine vector deep inside the fine domain', () => {
+		const { value, direction } = sample(0, 0);
+		expect(value).toBeCloseTo(10, 6);
+		expect(direction).toBeCloseTo(0, 6);
+	});
+
+	it('falls through to the coarse vector beyond the fine footprint', () => {
+		const { value, direction } = sample(0, 30);
+		expect(value).toBeCloseTo(10, 6);
+		expect(direction).toBeCloseTo(90, 6);
+	});
+
+	it('blends direction through component space across the edge zone', () => {
+		// Edge weight 0.5: U = 5, V = 5 → 45° bearing, magnitude √50.
+		const { value, direction } = sample(0, 9);
+		expect(direction).toBeCloseTo(45, 6);
+		expect(value).toBeCloseTo(Math.hypot(5, 5), 6);
+	});
+});
+
+describe('generateGridPoints across seamless layers', () => {
+	const decodeGrid = (sources: GridPointSource[]) => {
+		const pbf = new PbfWriter();
+		generateGridPoints(pbf, sources, 0, 0, 0, undefined);
+		const layer = new VectorTile(new PbfReader(pbf.finish())).layers['grid'];
+		const values: number[] = [];
+		for (let i = 0; i < (layer?.length ?? 0); i++) {
+			values.push(layer.feature(i).properties.value as number);
+		}
+		return values.sort((a, b) => a - b);
+	};
+
+	it('drops coarse points already covered by a finer domain', () => {
+		const fineGrid = {
+			getLinearInterpolatedValue: (_arr: Float32Array, lat: number, lon: number) =>
+				Math.abs(lat) <= 5 && Math.abs(lon) <= 5 ? 100 : NaN,
+			forEachPoint: (cb: (p: { index: number; lat: number; lon: number }) => void) => {
+				cb({ index: 0, lat: 0, lon: 0 });
+			}
+		} as unknown as GridInterface;
+		const coarseGrid = {
+			getLinearInterpolatedValue: () => 50,
+			forEachPoint: (cb: (p: { index: number; lat: number; lon: number }) => void) => {
+				cb({ index: 0, lat: 0, lon: 0 }); // inside fine → should be masked
+				cb({ index: 1, lat: 0, lon: 50 }); // outside fine → should remain
+			}
+		} as unknown as GridInterface;
+
+		const values = decodeGrid([
+			{ grid: fineGrid, values: new Float32Array([100]) },
+			{ grid: coarseGrid, values: new Float32Array([50, 50]) }
+		]);
+
+		// Fine point (100) plus the uncovered coarse point (50); the coarse point that
+		// coincides with the fine domain is masked out.
+		expect(values).toEqual([50, 100]);
+	});
+});
+
+describe('blend edge distance uses edgeGrids (full domain), not the value grids', () => {
+	it('fades the blend at the edgeGrid boundary even when the value grid covers everywhere', () => {
+		// Value grids cover the whole world (so coverage never falls through), but the
+		// edge grids describe a small FINE_BOUNDS domain. The blend must follow the
+		// edge grids — this is what lets the worker use full-domain grids for the blend
+		// while sampling values from viewport-cropped grids.
+		const valueFine = fakeGrid(10, 0, undefined, everywhere, WORLD_BOUNDS);
+		const valueCoarse = fakeGrid(0, 0, undefined, everywhere, WORLD_BOUNDS);
+		const edgeFine = fakeGrid(0, 0, undefined, everywhere, FINE_BOUNDS);
+		const edgeCoarse = fakeGrid(0, 0, undefined, everywhere, WORLD_BOUNDS);
+		const layers = [
+			fakeLayer(new Float32Array([10]), undefined, FINE_BOUNDS, 2),
+			fakeLayer(new Float32Array([0]), undefined, WORLD_BOUNDS, 0)
+		];
+		const sample = sampleBlendedValue([valueFine, valueCoarse], layers, [edgeFine, edgeCoarse]);
+
+		expect(sample(0, 0)).toBe(10); // deep inside the edge domain → fine value
+		expect(sample(0, 9)).toBeCloseTo(5, 6); // 1° from the FINE edge, blendWidth 2 → t=0.5
+	});
+});
+
+describe('sampleBlendedValue across a NULL-padded regular grid', () => {
+	it('fades the blend across the real data (NaN) boundary, not the grid box', () => {
+		// 11×11 grid spanning [-5,5]² with valid data only in the central 5×5 block
+		// (lon/lat -2..2); the rest is NaN, like a reprojected domain's padding.
+		const fineGridData: GridData = {
+			type: 'regular',
+			nx: 11,
+			ny: 11,
+			latMin: -5,
+			lonMin: -5,
+			dx: 1,
+			dy: 1,
+			zoom: 1
+		};
+		const globalGridData: GridData = {
+			type: 'regular',
+			nx: 36,
+			ny: 18,
+			latMin: -90,
+			lonMin: -180,
+			dx: 10,
+			dy: 10,
+			zoom: 1
+		};
+		const fineGrid = GridFactory.create(fineGridData);
+		const globalGrid = GridFactory.create(globalGridData);
+
+		const fineVals = new Float32Array(121).fill(NaN);
+		for (let yy = 3; yy <= 7; yy++) for (let xx = 3; xx <= 7; xx++) fineVals[yy * 11 + xx] = 10;
+		const globalVals = new Float32Array(36 * 18).fill(0);
+
+		const layers: SeamlessLayerRenderData[] = [
+			{
+				domain: { value: 'fine', grid: fineGridData } as Domain,
+				data: { values: fineVals, directions: undefined },
+				ranges: [
+					{ start: 0, end: 11 },
+					{ start: 0, end: 11 }
+				],
+				domainBounds: fineGrid.getBounds(),
+				blendWidthDeg: 2,
+				nanFieldKey: 'test-null-padded-fine'
+			},
+			{
+				domain: { value: 'global', grid: globalGridData } as Domain,
+				data: { values: globalVals, directions: undefined },
+				ranges: [
+					{ start: 0, end: 18 },
+					{ start: 0, end: 36 }
+				],
+				domainBounds: globalGrid.getBounds(),
+				blendWidthDeg: 0
+			}
+		];
+		const sample = sampleBlendedValue([fineGrid, globalGrid], layers);
+
+		expect(sample(0, 0)).toBeCloseTo(10, 5); // deep inside the valid block → fine
+		expect(sample(0, 4)).toBe(0); // NaN padding → falls through to the global 0
+		// Just inside the valid block, ~1.4° from the NaN edge: blended (a box-based
+		// blend would report this as deep inside → a hard 10).
+		const blended = sample(0, 1.6);
+		expect(blended).toBeGreaterThan(0);
+		expect(blended).toBeLessThan(10);
+	});
+});

--- a/src/tests/seamless.test.ts
+++ b/src/tests/seamless.test.ts
@@ -1,0 +1,589 @@
+/**
+ * Comprehensive tests for the SeamlessDomain / handleSeamlessRequest feature.
+ *
+ * Covers:
+ *  - TileJSON returned immediately (no data load) with correct bounds
+ *  - Clipping applied to seamless TileJSON bounds
+ *  - Zoom-level layer filtering (minZoom gating)
+ *  - Parallel data loading (reads start finest-first)
+ *  - postReadCallback IS invoked once per real sub-layer load
+ *  - Correct URL substitution for each concrete layer
+ *  - Failed layers are skipped; surviving layers still render
+ *  - All layers failing returns { data: null }
+ *  - Abort signal stops layer loading mid-way
+ *  - State cache: second request for same data is instant (no re-read)
+ *  - Unsupported request type throws
+ *  - Missing tile coordinates throws for image requests
+ *  - SeamlessDomain exposes time_interval and model_interval
+ */
+import { defaultOmProtocolSettings } from '../om-protocol';
+import { updateCurrentBounds } from '../utils/bounds';
+import { RequestParameters } from 'maplibre-gl';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+	DimensionRange,
+	Domain,
+	OmProtocolSettings,
+	SeamlessDomain,
+	TileJSON
+} from '../types';
+
+// ─── Hoisted mutable state shared between mock factories ──────────────────────
+
+const { mockReturnBuffer, mockReadVariableSpy, mockShouldFail, mockOnReadVariable } = vi.hoisted(
+	() => ({
+		mockReturnBuffer: { value: new ArrayBuffer(16) },
+		/** All URLs passed to readVariable() in call order. */
+		mockReadVariableSpy: { calls: [] as string[] },
+		/** Set of URL path substrings whose readVariable should throw. */
+		mockShouldFail: { substrings: new Set<string>() },
+		/** Optional hook called synchronously at the start of readVariable. */
+		mockOnReadVariable: { fn: undefined as ((url: string) => void) | undefined }
+	})
+);
+
+// ─── Module mocks ─────────────────────────────────────────────────────────────
+
+vi.mock('../om-file-reader', async () => {
+	const actual = await vi.importActual('../om-file-reader');
+	return {
+		...actual,
+		WeatherMapLayerFileReader: class {
+			config: Record<string, unknown>;
+			constructor(config: Record<string, unknown>) {
+				this.config = config;
+			}
+
+			async readVariable(
+				omUrl: string,
+				_variable: string,
+				ranges: DimensionRange[],
+				signal?: AbortSignal
+			): Promise<{ values: Float32Array; directions: undefined }> {
+				mockReadVariableSpy.calls.push(omUrl);
+				mockOnReadVariable.fn?.(omUrl);
+				if (signal?.aborted) {
+					throw new DOMException('Aborted', 'AbortError');
+				}
+				for (const sub of mockShouldFail.substrings) {
+					if (omUrl.includes(sub)) {
+						throw new Error(`Simulated failure for: ${sub}`);
+					}
+				}
+				const totalValues = ranges?.reduce((acc, r) => acc * (r.end - r.start + 1), 1) ?? 0;
+				return { values: new Float32Array(totalValues), directions: undefined };
+			}
+
+			async warmFile(_omUrl: string): Promise<void> {}
+		}
+	};
+});
+
+vi.mock('../worker-pool', () => ({
+	WorkerPool: class {
+		requestTile = vi.fn(() => Promise.resolve(mockReturnBuffer.value));
+	}
+}));
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+	vi.resetModules();
+	vi.clearAllMocks();
+	mockReturnBuffer.value = new ArrayBuffer(16);
+	mockReadVariableSpy.calls = [];
+	mockShouldFail.substrings.clear();
+	mockOnReadVariable.fn = undefined;
+	// Default to a world-covering viewport so the seamless viewport gate never
+	// excludes a layer; tests that exercise the gate override this explicitly.
+	updateCurrentBounds([-180, -90, 180, 90]);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Shared domain/settings factories
+// ---------------------------------------------------------------------------
+
+/** Create a minimal regular-grid Domain. */
+const makeRegularDomain = (
+	value: string,
+	opts: {
+		nx?: number;
+		ny?: number;
+		lonMin?: number;
+		latMin?: number;
+		dx?: number;
+		dy?: number;
+	} = {}
+): Domain => ({
+	value,
+	label: `Test ${value}`,
+	grid: {
+		type: 'regular',
+		nx: opts.nx ?? 10,
+		ny: opts.ny ?? 10,
+		lonMin: opts.lonMin ?? -10,
+		latMin: opts.latMin ?? -10,
+		dx: opts.dx ?? 2,
+		dy: opts.dy ?? 2
+	},
+	time_interval: 'hourly',
+	model_interval: '3_hourly'
+});
+
+/** Concrete domain trio mirroring the real DWD ICON seamless stack. */
+const GLOBAL_DOMAIN = makeRegularDomain('test_global', {
+	nx: 20,
+	ny: 20,
+	lonMin: -20,
+	latMin: -20,
+	dx: 2,
+	dy: 2
+});
+const EU_DOMAIN = makeRegularDomain('test_eu', {
+	nx: 10,
+	ny: 10,
+	lonMin: -5,
+	latMin: -5,
+	dx: 1,
+	dy: 1
+});
+const D2_DOMAIN = makeRegularDomain('test_d2', {
+	nx: 6,
+	ny: 6,
+	lonMin: -1,
+	latMin: -1,
+	dx: 0.4,
+	dy: 0.4
+});
+
+const SEAMLESS: SeamlessDomain = {
+	type: 'seamless',
+	value: 'test_seamless',
+	label: 'Test Seamless',
+	time_interval: 'hourly',
+	model_interval: '3_hourly',
+	layers: [
+		{ domainValue: 'test_d2', minZoom: 5, blendWidthDeg: 0.5 },
+		{ domainValue: 'test_eu', minZoom: 3, blendWidthDeg: 1.5 },
+		{ domainValue: 'test_global', minZoom: 0, blendWidthDeg: 0 }
+	]
+};
+
+const makeSettings = (overrides: Partial<OmProtocolSettings> = {}): OmProtocolSettings => ({
+	...defaultOmProtocolSettings,
+	domainOptions: [GLOBAL_DOMAIN, EU_DOMAIN, D2_DOMAIN, SEAMLESS],
+	...overrides
+});
+
+/** Base URL segment used in test om:// URLs. */
+const BASE = 'https://example.com/data_spatial/test_seamless/2025/01/01/0000Z/2025-01-01T0000.om';
+
+const jsonParams = (): RequestParameters => ({
+	url: `om://${BASE}?variable=temperature`,
+	type: 'json'
+});
+
+const tileParams = (z: number, x = 0, y = 0): RequestParameters => ({
+	url: `om://${BASE}?variable=temperature/${z}/${x}/${y}`,
+	type: 'arrayBuffer'
+});
+
+// ─── Test suites ──────────────────────────────────────────────────────────────
+
+describe('SeamlessDomain – TileJSON', () => {
+	it('returns TileJSON immediately without loading any data', async () => {
+		const { omProtocol } = await import('../om-protocol');
+		const result = await omProtocol(jsonParams(), new AbortController(), makeSettings());
+
+		expect(result.data).not.toBeNull();
+		const tj = result.data as TileJSON;
+		expect(tj.tilejson).toBe('3.0.0');
+		expect(tj.minzoom).toBe(0);
+		expect(tj.maxzoom).toBe(12);
+
+		// No data was loaded — readVariable should not have been called
+		expect(mockReadVariableSpy.calls).toHaveLength(0);
+	});
+
+	it('TileJSON tiles URL matches the request URL', async () => {
+		const { omProtocol } = await import('../om-protocol');
+		const params = jsonParams();
+		const result = await omProtocol(params, new AbortController(), makeSettings());
+
+		const tj = result.data as TileJSON;
+		expect(tj.tiles[0]).toBe(`${params.url}/{z}/{x}/{y}`);
+	});
+
+	it('TileJSON bounds come from the global (last) layer domain', async () => {
+		const { omProtocol } = await import('../om-protocol');
+		const result = await omProtocol(jsonParams(), new AbortController(), makeSettings());
+
+		const tj = result.data as TileJSON;
+		expect(tj.bounds).toHaveLength(4);
+		expect(tj.bounds).toEqual([-20, -20, 20, 20]);
+	});
+
+	it('TileJSON bounds are clipped when clippingOptions are set', async () => {
+		const { omProtocol } = await import('../om-protocol');
+		const settings = makeSettings({
+			clippingOptions: { bounds: [-5, -5, 5, 5] }
+		});
+		const result = await omProtocol(jsonParams(), new AbortController(), settings);
+
+		const tj = result.data as TileJSON;
+		const [lonMin, latMin, lonMax, latMax] = tj.bounds!;
+		expect(lonMin).toBeGreaterThanOrEqual(-5);
+		expect(latMin).toBeGreaterThanOrEqual(-5);
+		expect(lonMax).toBeLessThanOrEqual(5);
+		expect(latMax).toBeLessThanOrEqual(5);
+	});
+
+	it('returns { data: null } when the global backing domain is not in settings', async () => {
+		const { omProtocol } = await import('../om-protocol');
+		// Remove the global concrete domain from the domain list
+		const settings = makeSettings({
+			domainOptions: [EU_DOMAIN, D2_DOMAIN, SEAMLESS]
+		});
+		const result = await omProtocol(jsonParams(), new AbortController(), settings);
+		expect(result.data).toBeNull();
+	});
+});
+
+describe('SeamlessDomain – zoom-level layer filtering', () => {
+	it('at zoom 0 only global layer is active', async () => {
+		const { omProtocol } = await import('../om-protocol');
+		await omProtocol(tileParams(0), new AbortController(), makeSettings());
+
+		// Only global domain URL should have been opened
+		const urls = mockReadVariableSpy.calls;
+		expect(urls).toHaveLength(1);
+		expect(urls[0]).toContain('/test_global/');
+	});
+
+	it('at zoom 3 eu + global layers are active (d2 skipped)', async () => {
+		const { omProtocol } = await import('../om-protocol');
+		await omProtocol(tileParams(3), new AbortController(), makeSettings());
+
+		const domainValues = mockReadVariableSpy.calls.map(
+			(u) => u.match(/\/data_spatial\/([^/]+)\//)?.[1]
+		);
+		// eu (minZoom 3) and global (minZoom 0) — d2 (minZoom 5) must be absent
+		expect(domainValues).toContain('test_eu');
+		expect(domainValues).toContain('test_global');
+		expect(domainValues).not.toContain('test_d2');
+	});
+
+	it('at zoom 5 all three layers (d2, eu, global) are active', async () => {
+		const { omProtocol } = await import('../om-protocol');
+		await omProtocol(tileParams(5), new AbortController(), makeSettings());
+
+		const domainValues = mockReadVariableSpy.calls.map(
+			(u) => u.match(/\/data_spatial\/([^/]+)\//)?.[1]
+		);
+		expect(domainValues).toContain('test_d2');
+		expect(domainValues).toContain('test_eu');
+		expect(domainValues).toContain('test_global');
+	});
+
+	it('at zoom 4 (between 3 and 5) only eu + global are active', async () => {
+		const { omProtocol } = await import('../om-protocol');
+		await omProtocol(tileParams(4), new AbortController(), makeSettings());
+
+		const domainValues = mockReadVariableSpy.calls.map(
+			(u) => u.match(/\/data_spatial\/([^/]+)\//)?.[1]
+		);
+		expect(domainValues).not.toContain('test_d2');
+		expect(domainValues).toContain('test_eu');
+		expect(domainValues).toContain('test_global');
+	});
+});
+
+describe('SeamlessDomain – viewport gating', () => {
+	// test_d2 covers lon/lat ~[-1, 1.4]; test_eu ~[-5, 5]; test_global ~[-20, 18].
+
+	it('loads regional layers that overlap the viewport', async () => {
+		updateCurrentBounds([-2, -2, 0, 0]); // overlaps d2, eu and global
+		const { omProtocol } = await import('../om-protocol');
+		await omProtocol(tileParams(5), new AbortController(), makeSettings());
+
+		const domainValues = mockReadVariableSpy.calls.map(
+			(u) => u.match(/\/data_spatial\/([^/]+)\//)?.[1]
+		);
+		expect(domainValues).toContain('test_d2');
+		expect(domainValues).toContain('test_eu');
+		expect(domainValues).toContain('test_global');
+	});
+
+	it('skips a regional layer entirely when it is off-screen', async () => {
+		updateCurrentBounds([100, 50, 110, 60]); // far from every regional domain
+		const { omProtocol } = await import('../om-protocol');
+		await omProtocol(tileParams(5), new AbortController(), makeSettings());
+
+		const domainValues = mockReadVariableSpy.calls.map(
+			(u) => u.match(/\/data_spatial\/([^/]+)\//)?.[1]
+		);
+		// Off-screen regional layers are never fetched...
+		expect(domainValues).not.toContain('test_d2');
+		expect(domainValues).not.toContain('test_eu');
+		// ...but the global fallback is always loaded, even out of its (test) bounds.
+		expect(domainValues).toContain('test_global');
+	});
+
+	it('loads only the regional layers that overlap a partial viewport', async () => {
+		// Overlaps eu (lon ≤ 5) but not d2 (lon ≤ 1.4): a viewport east of d2.
+		updateCurrentBounds([3, 3, 5, 5]);
+		const { omProtocol } = await import('../om-protocol');
+		await omProtocol(tileParams(5), new AbortController(), makeSettings());
+
+		const domainValues = mockReadVariableSpy.calls.map(
+			(u) => u.match(/\/data_spatial\/([^/]+)\//)?.[1]
+		);
+		expect(domainValues).not.toContain('test_d2');
+		expect(domainValues).toContain('test_eu');
+		expect(domainValues).toContain('test_global');
+	});
+});
+
+describe('SeamlessDomain – parallel data loading', () => {
+	it('layer reads start in finest-first order', async () => {
+		// Layers load in parallel, but the reads are issued in layer-definition
+		// order. We verify the start order: d2 → eu → global (finest first).
+		const { omProtocol } = await import('../om-protocol');
+		await omProtocol(tileParams(5), new AbortController(), makeSettings());
+
+		const domainOrder = mockReadVariableSpy.calls.map(
+			(u) => u.match(/\/data_spatial\/([^/]+)\//)?.[1]
+		);
+		// Layers are finest-first in the seamless definition
+		expect(domainOrder).toEqual(['test_d2', 'test_eu', 'test_global']);
+	});
+
+	it('each read receives its own layer URL', async () => {
+		// Reads are atomic (URL passed per call), so no reader state can bleed
+		// between layers; each call must carry exactly its layer's concrete URL.
+		const { omProtocol } = await import('../om-protocol');
+		await omProtocol(tileParams(5), new AbortController(), makeSettings());
+
+		expect(mockReadVariableSpy.calls[0]).toContain('/test_d2/');
+		expect(mockReadVariableSpy.calls[1]).toContain('/test_eu/');
+		expect(mockReadVariableSpy.calls[2]).toContain('/test_global/');
+	});
+});
+
+describe('SeamlessDomain – URL substitution', () => {
+	it('substitutes the seamless domain name with each concrete domain name', async () => {
+		const { omProtocol } = await import('../om-protocol');
+		await omProtocol(tileParams(5), new AbortController(), makeSettings());
+
+		const urls = mockReadVariableSpy.calls;
+		expect(urls).toHaveLength(3);
+		// Path structure is preserved; only the domain segment changes
+		for (const url of urls) {
+			expect(url).not.toContain('/test_seamless/');
+			expect(url).toContain('2025/01/01/0000Z/2025-01-01T0000.om');
+		}
+		expect(urls[0]).toContain('/test_d2/');
+		expect(urls[1]).toContain('/test_eu/');
+		expect(urls[2]).toContain('/test_global/');
+	});
+});
+
+describe('SeamlessDomain – error handling', () => {
+	it('a failing layer is skipped; the remaining layers still produce a tile', async () => {
+		// d2 fails → only eu + global are used
+		mockShouldFail.substrings.add('/test_d2/');
+		const { omProtocol } = await import('../om-protocol');
+		const result = await omProtocol(tileParams(5), new AbortController(), makeSettings());
+
+		expect(result.data).toBeInstanceOf(ArrayBuffer);
+		// eu and global should still have been loaded
+		const domainValues = mockReadVariableSpy.calls.map(
+			(u) => u.match(/\/data_spatial\/([^/]+)\//)?.[1]
+		);
+		expect(domainValues).toContain('test_eu');
+		expect(domainValues).toContain('test_global');
+	});
+
+	it('all layers failing returns { data: null }', async () => {
+		mockShouldFail.substrings.add('/test_d2/');
+		mockShouldFail.substrings.add('/test_eu/');
+		mockShouldFail.substrings.add('/test_global/');
+		const { omProtocol } = await import('../om-protocol');
+		const result = await omProtocol(tileParams(5), new AbortController(), makeSettings());
+
+		expect(result.data).toBeNull();
+	});
+
+	it('unsupported request type throws', async () => {
+		const { omProtocol } = await import('../om-protocol');
+		const params: RequestParameters = {
+			url: `om://${BASE}?variable=temperature/0/0/0`,
+			type: 'image'
+		};
+		// 'image' tiles carry z/x/y, so this path IS reachable in handleSeamlessRequest
+		// (it should succeed, not throw, since 'image' is handled by requestTileSeamless)
+		// — only truly unknown types throw
+		const unknownParams = { ...params, type: 'vector' as RequestParameters['type'] };
+		await expect(omProtocol(unknownParams, new AbortController(), makeSettings())).rejects.toThrow(
+			"Unsupported request type 'vector'"
+		);
+	});
+
+	it('tile request without z/x/y throws', async () => {
+		const { omProtocol } = await import('../om-protocol');
+		const params: RequestParameters = {
+			url: `om://${BASE}?variable=temperature`,
+			type: 'arrayBuffer'
+		};
+		await expect(omProtocol(params, new AbortController(), makeSettings())).rejects.toThrow(
+			'Tile coordinates required'
+		);
+	});
+});
+
+describe('SeamlessDomain – abort signal', () => {
+	it('aborted signal before TileJSON returns { data: null } immediately', async () => {
+		const { omProtocol } = await import('../om-protocol');
+		const ac = new AbortController();
+		ac.abort();
+		const result = await omProtocol(jsonParams(), ac, makeSettings());
+		expect(result.data).toBeNull();
+	});
+
+	it('aborted signal before tile request returns { data: null }', async () => {
+		const { omProtocol } = await import('../om-protocol');
+		const ac = new AbortController();
+		ac.abort();
+		const result = await omProtocol(tileParams(5), ac, makeSettings());
+		expect(result.data).toBeNull();
+	});
+
+	it('abort during the first layer read stops further layer fetches', async () => {
+		// The abort fires synchronously inside the first (d2) read, before the other
+		// layer tasks reach their signal check — eu and global must not be started.
+		const ac = new AbortController();
+		mockOnReadVariable.fn = () => ac.abort();
+
+		const { omProtocol } = await import('../om-protocol');
+		const result = await omProtocol(tileParams(5), ac, makeSettings());
+
+		// Only the first readVariable ran before the abort propagated
+		expect(mockReadVariableSpy.calls).toHaveLength(1);
+		expect(result.data).toBeNull();
+	});
+});
+
+describe('SeamlessDomain – state caching', () => {
+	it('second tile request uses cached state; readVariable called only once per layer', async () => {
+		const { omProtocol } = await import('../om-protocol');
+		const settings = makeSettings();
+
+		// First request populates the cache
+		await omProtocol(tileParams(5), new AbortController(), settings);
+		const firstCallCount = mockReadVariableSpy.calls.length;
+
+		// Second request should hit state.data — no new readVariable calls
+		await omProtocol(tileParams(5), new AbortController(), settings);
+		expect(mockReadVariableSpy.calls).toHaveLength(firstCallCount);
+	});
+});
+
+describe('SeamlessDomain – postReadCallback', () => {
+	it('invokes postReadCallback once per real sub-layer load', async () => {
+		const { omProtocol } = await import('../om-protocol');
+		const postReadCallback = vi.fn();
+		const settings = makeSettings({ postReadCallback });
+
+		// zoom 5 loads all three layers (d2, eu, global)
+		await omProtocol(tileParams(5), new AbortController(), settings);
+
+		expect(postReadCallback).toHaveBeenCalledTimes(3);
+		const domainValues = postReadCallback.mock.calls.map(
+			([, , state]) => state.omFileUrl.match(/\/data_spatial\/([^/]+)\//)?.[1]
+		);
+		expect(domainValues).toEqual(['test_d2', 'test_eu', 'test_global']);
+	});
+
+	it('does not re-invoke postReadCallback for cached sub-layer state', async () => {
+		const { omProtocol } = await import('../om-protocol');
+		const postReadCallback = vi.fn();
+		const settings = makeSettings({ postReadCallback });
+
+		await omProtocol(tileParams(5), new AbortController(), settings);
+		postReadCallback.mockClear();
+
+		// Second request hits state.data — ensureData short-circuits, no callback
+		await omProtocol(tileParams(5), new AbortController(), settings);
+		expect(postReadCallback).not.toHaveBeenCalled();
+	});
+});
+
+describe('SeamlessDomain – type properties', () => {
+	it('dwd_icon_seamless exposes time_interval and model_interval', async () => {
+		const { domainOptions } = await import('../domains');
+		const seamless = domainOptions.find((d) => d.value === 'dwd_icon_seamless') as SeamlessDomain;
+		expect(seamless).toBeDefined();
+		expect(seamless.time_interval).toBe('hourly');
+		expect(seamless.model_interval).toBe('3_hourly');
+	});
+
+	it('SeamlessDomain is included in domainOptions', async () => {
+		const { domainOptions } = await import('../domains');
+		const found = domainOptions.find((d) => d.value === 'dwd_icon_seamless');
+		expect(found).toBeDefined();
+		expect((found as SeamlessDomain).type).toBe('seamless');
+		expect((found as SeamlessDomain).layers).toHaveLength(3);
+	});
+
+	it('constituent layer domainValues reference real Domain entries', async () => {
+		const { domainOptions } = await import('../domains');
+		const seamless = domainOptions.find((d) => d.value === 'dwd_icon_seamless') as SeamlessDomain;
+		for (const layer of seamless.layers) {
+			const concrete = domainOptions.find((d) => d.value === layer.domainValue && !('layers' in d));
+			expect(concrete).toBeDefined();
+		}
+	});
+
+	it('seamless layers are ordered finest-first (highest minZoom first)', async () => {
+		const { domainOptions } = await import('../domains');
+		const seamless = domainOptions.find((d) => d.value === 'dwd_icon_seamless') as SeamlessDomain;
+		const zooms = seamless.layers.map((l) => l.minZoom);
+		// Each entry must have a zoom >= the next entry (descending or equal)
+		for (let i = 0; i < zooms.length - 1; i++) {
+			expect(zooms[i]).toBeGreaterThanOrEqual(zooms[i + 1]);
+		}
+	});
+
+	it('global fallback layer has blendWidthDeg of 0', async () => {
+		const { domainOptions } = await import('../domains');
+		const seamless = domainOptions.find((d) => d.value === 'dwd_icon_seamless') as SeamlessDomain;
+		const last = seamless.layers[seamless.layers.length - 1];
+		expect(last.blendWidthDeg).toBe(0);
+	});
+});
+
+describe('SeamlessDomain – real dwd_icon_seamless TileJSON', () => {
+	it('returns valid TileJSON for dwd_icon_seamless URL', async () => {
+		const { omProtocol, defaultOmProtocolSettings } = await import('../om-protocol');
+		const url =
+			'om://https://map-tiles.open-meteo.com/data_spatial/dwd_icon_seamless/2025/01/01/0000Z/2025-01-01T0000.om?variable=temperature_2m';
+		const result = await omProtocol(
+			{ url, type: 'json' },
+			new AbortController(),
+			defaultOmProtocolSettings
+		);
+		expect(result.data).not.toBeNull();
+		const tj = result.data as TileJSON;
+		expect(tj.tilejson).toBe('3.0.0');
+		// Bounds should span the dwd_icon global domain
+		expect(tj.bounds).toBeDefined();
+		expect(tj.bounds!.every(Number.isFinite)).toBe(true);
+		// No data was loaded
+		expect(mockReadVariableSpy.calls).toHaveLength(0);
+	});
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export interface OmProtocolInstance {
 }
 
 export interface DataIdentityOptions {
-	domain: Domain;
+	domain: AnyDomain;
 	variable: string;
 	bounds: Bounds | undefined;
 }
@@ -74,7 +74,7 @@ export interface OmProtocolSettings {
 
 	// dynamic
 	colorScales: ColorScales;
-	domainOptions: Domain[];
+	domainOptions: AnyDomain[];
 	clippingOptions: ClippingOptions;
 
 	/**
@@ -123,6 +123,25 @@ export type TileIndex = {
 	y: number;
 };
 
+/**
+ * Data for one concrete domain layer in a seamless composite request.
+ * Passed to the worker so it can blend values across domain boundaries.
+ */
+export interface SeamlessLayerRenderData {
+	domain: Domain;
+	data: Data;
+	ranges: DimensionRange[];
+	/** Full geographic bounds of this domain (not viewport-cropped). */
+	domainBounds: Bounds;
+	blendWidthDeg: number;
+	/**
+	 * Stable identity (URL + ranges) of this layer's data, used by the worker to
+	 * cache its NaN-distance field so the blend can follow the real (non-NULL)
+	 * data shape. Only set for blending regular-grid layers; absent otherwise.
+	 */
+	nanFieldKey?: string;
+}
+
 export interface TileRequest {
 	type: 'getArrayBuffer' | 'getImage' | 'cancel';
 	key: string;
@@ -133,6 +152,8 @@ export interface TileRequest {
 	ranges: DimensionRange[];
 	clippingOptions: ResolvedClippingOptions | undefined;
 	signal?: AbortSignal;
+	/** Present when the original request was for a seamless composite domain. */
+	seamlessLayers?: SeamlessLayerRenderData[];
 }
 
 export type WorkerRequest = TileRequest;
@@ -310,6 +331,7 @@ export interface Domain {
 	grid: GridData;
 	time_interval: ModelDt;
 	model_interval: ModelUpdateInterval;
+	windUVComponents?: boolean;
 }
 
 export type ModelDt =
@@ -325,8 +347,54 @@ export type ModelDt =
 export type ModelUpdateInterval =
 	'hourly' | '3_hourly' | '6_hourly' | '12_hourly' | 'daily' | 'monthly';
 
+/** A single layer within a seamless domain, referencing a concrete grid-based domain. */
+export interface SeamlessLayer {
+	/** The `value` of a concrete `Domain` entry to use for this layer. */
+	domainValue: string;
+	/** This layer is only used when the map zoom level is >= minZoom. */
+	minZoom: number;
+	/**
+	 * Width of the blend zone in degrees at the edges of this layer's geographic bounds.
+	 * 0 means no blending (hard cut); only meaningful for layers that aren't global.
+	 */
+	blendWidthDeg: number;
+	/**
+	 * Maximum lead time in hours that this layer's model produces forecast data for.
+	 * When the requested timestep exceeds this horizon the layer is skipped entirely,
+	 * falling through to the next coarser layer instead of issuing a request that
+	 * would return a 404 (which browsers surface as a CORS error).
+	 */
+	maxForecastHours?: number;
+}
+
+/**
+ * A virtual domain that automatically picks and blends several concrete domains
+ * based on the current zoom level.  Layers should be ordered from the
+ * highest-resolution/most-specific (first) to the global fallback (last).
+ */
+export interface SeamlessDomain {
+	value: string;
+	label?: string;
+	type: 'seamless';
+	layers: SeamlessLayer[];
+	/**
+	 * Time resolution shared by all constituent layers.
+	 * Mirrors the `time_interval` on `Domain` so consuming code can treat
+	 * `AnyDomain` uniformly for time-navigation purposes.
+	 */
+	time_interval?: ModelDt;
+	/**
+	 * Model-run update cadence shared by all constituent layers.
+	 * Mirrors the `model_interval` on `Domain`.
+	 */
+	model_interval?: ModelUpdateInterval;
+}
+
+/** Union of a regular grid domain and a seamless composite domain. */
+export type AnyDomain = Domain | SeamlessDomain;
+
 export interface DomainGroups {
-	[key: string]: Domain[];
+	[key: string]: AnyDomain[];
 }
 
 export type Bounds = [

--- a/src/utils/arrows.ts
+++ b/src/utils/arrows.ts
@@ -1,23 +1,18 @@
-import { GridInterface } from '../grids';
 import { PbfWriter } from 'pbf';
 
 import { type ResolvedClippingOptions, createClippingTester } from './clipping';
 import { VECTOR_TILE_EXTENT } from './constants';
 import { degreesToRadians, rotatePoint, tile2lat, tile2lon } from './math';
 import { command, writeLayer, zigzag } from './pbf';
-
-import { InterpolationMethod } from '../types';
+import type { VectorSampler } from './seamless-sampling';
 
 export const generateArrows = (
 	pbf: PbfWriter,
-	values: Float32Array,
-	directions: Float32Array,
-	grid: GridInterface,
+	sampleVector: VectorSampler,
 	x: number,
 	y: number,
 	z: number,
 	clippingOptions: ResolvedClippingOptions | undefined,
-	interpolation: InterpolationMethod = 'linear',
 	extent: number = VECTOR_TILE_EXTENT,
 	arrows: number = 25
 ) => {
@@ -48,13 +43,8 @@ export const generateArrows = (
 				continue;
 			}
 
-			// Sample speed with the selected method so arrow size/colour matches
-			// the raster; direction is blended circularly (scalar averaging flips
-			// arrows near the 0°/360° seam).
-			const speed = grid.getInterpolatedValue(values, lat, lon, interpolation);
-			const direction = degreesToRadians(
-				grid.getLinearInterpolatedDirection(directions, lat, lon) + 180
-			);
+			const { value: speed, direction: directionDeg } = sampleVector(lat, lon);
+			const direction = degreesToRadians(directionDeg + 180);
 
 			const properties: { value?: number; direction?: number } = {
 				value: speed,

--- a/src/utils/contours.ts
+++ b/src/utils/contours.ts
@@ -1,16 +1,14 @@
-import { GridInterface } from '../grids/index';
 import { PbfWriter } from 'pbf';
 
 import { type ResolvedClippingOptions, createClippingTester } from './clipping';
 import { VECTOR_TILE_EXTENT } from './constants';
 import { tile2lat, tile2lon } from './math';
 import { command, writeLayer, zigzag } from './pbf';
-
-import { InterpolationMethod } from '../types';
+import type { ValueSampler } from './seamless-sampling';
 
 // prettier-ignore
 export const CASES: [number, number][][][] = [
-	[],					       // 0
+	[],					       			// 0
 	[[[1, 2],[0, 1]]],			  // 1
 	[[[2, 1],[1, 2]]],			  // 2
 	[[[2, 1],[0, 1]]],			  // 3
@@ -141,15 +139,13 @@ const isAscending = (arr: number[]): boolean => {
 
 export const generateContours = (
 	pbf: PbfWriter,
-	values: Float32Array,
-	grid: GridInterface,
+	sampleValue: ValueSampler,
 	x: number,
 	y: number,
 	z: number,
 	tileSize: number,
 	intervals: number[],
 	clippingOptions: ResolvedClippingOptions | undefined,
-	interpolation: InterpolationMethod = 'linear',
 	// Added to every sample so contour crossings fall off the quantization grid,
 	// matching the raster (see halfQuantum / worker). Keeps contours aligned with
 	// the colour band edges.
@@ -257,7 +253,7 @@ export const generateContours = (
 
 	const sampleRow = (lat: number, out: Float64Array): void => {
 		for (let c = 0; c < numCols; c++) {
-			out[c] = grid.getInterpolatedValue(values, lat, lons[c], interpolation) + valueOffset;
+			out[c] = sampleValue(lat, lons[c]) + valueOffset;
 		}
 	};
 

--- a/src/utils/grid-points.ts
+++ b/src/utils/grid-points.ts
@@ -16,15 +16,26 @@ const tile2lonUnwrapped = (x: number, z: number): number => {
 	return (x / Math.pow(2, z)) * 360 - 180;
 };
 
+/** One concrete domain's native grid + data for the grid-point layer. */
+export interface GridPointSource {
+	grid: GridInterface;
+	values: Float32Array;
+	directions?: Float32Array;
+}
+
 /**
  * Generate the PBF grid-point layer for a single tile.
- * Computes tile geographic bounds that intersects with `clippingBounds` if defined
+ *
+ * `sources` are ordered finest-first.  A point from a coarser source is dropped
+ * when a finer source already covers that location, so seamless composite domains
+ * render the best-available grid everywhere without overlapping markers.  A
+ * regular domain simply passes a single-element `sources` array.
+ *
+ * Computes tile geographic bounds that intersect with `clippingBounds` if defined.
  */
 export const generateGridPoints = (
 	pbf: PbfWriter,
-	grid: GridInterface,
-	values: Float32Array,
-	directions: Float32Array | undefined,
+	sources: GridPointSource[],
 	x: number,
 	y: number,
 	z: number,
@@ -72,35 +83,53 @@ export const generateGridPoints = (
 		return;
 	}
 
-	grid.forEachPoint(({ index, lat, lon }) => {
-		const worldPx = Math.floor(lon2tile(lon, z) * extent);
-		const worldPy = Math.floor(lat2tile(lat, z) * extent);
-
-		const px = worldPx - tileOffsetX;
-		const py = worldPy - tileOffsetY;
-		if (px < -margin || px > extent + margin) return;
-		if (py < -margin || py > extent + margin) return;
-
-		const value = values[index];
-		if (isNaN(value)) return;
-
-		if (isInsideClip && !isInsideClip(lon, lat)) {
-			return;
+	/** True when a finer source than `sourceIndex` already has data at (lat, lon). */
+	const coveredByFiner = (sourceIndex: number, lat: number, lon: number): boolean => {
+		for (let j = 0; j < sourceIndex; j++) {
+			if (isFinite(sources[j].grid.getLinearInterpolatedValue(sources[j].values, lat, lon))) {
+				return true;
+			}
 		}
+		return false;
+	};
 
-		const properties: { value?: number; direction?: number } = {};
-		properties.value = Number(value.toFixed(2));
-		if (directions) {
-			properties.direction = directions[index];
-		}
+	sources.forEach((source, sourceIndex) => {
+		source.grid.forEachPoint(({ index, lat, lon }) => {
+			const worldPx = Math.floor(lon2tile(lon, z) * extent);
+			const worldPy = Math.floor(lat2tile(lat, z) * extent);
 
-		features.push({
-			id: index,
-			type: 1, // Point
-			properties,
-			geom: [command(1, 1), zigzag(px), zigzag(py)]
-		});
-	}, iterBounds);
+			const px = worldPx - tileOffsetX;
+			const py = worldPy - tileOffsetY;
+			if (px < -margin || px > extent + margin) return;
+			if (py < -margin || py > extent + margin) return;
+
+			const value = source.values[index];
+			if (isNaN(value)) return;
+
+			if (isInsideClip && !isInsideClip(lon, lat)) {
+				return;
+			}
+
+			// Skip points already represented by a finer domain to avoid double markers.
+			if (sourceIndex > 0 && coveredByFiner(sourceIndex, lat, lon)) {
+				return;
+			}
+
+			const properties: { value?: number; direction?: number } = {};
+			properties.value = Number(value.toFixed(2));
+			if (source.directions) {
+				properties.direction = source.directions[index];
+			}
+
+			features.push({
+				// Offset by source so ids stay unique across stacked domains.
+				id: sourceIndex * 100_000_000 + index,
+				type: 1, // Point
+				properties,
+				geom: [command(1, 1), zigzag(px), zigzag(py)]
+			});
+		}, iterBounds);
+	});
 
 	// write Layer
 	pbf.writeMessage(3, writeLayer, {

--- a/src/utils/parse-request.ts
+++ b/src/utils/parse-request.ts
@@ -13,10 +13,10 @@ import { parseUrlComponents } from './parse-url';
 import { getColorScale, resolveColorScale } from './styling';
 
 import type {
+	AnyDomain,
 	ClippingOptions,
 	ColorScales,
 	DataIdentityOptions,
-	Domain,
 	InterpolationMethod,
 	OmProtocolSettings,
 	ParsedRequest,
@@ -77,7 +77,7 @@ export const defaultResolveRequest = (
 
 const defaultResolveDataIdentity = (
 	urlComponents: ParsedUrlComponents,
-	domainOptions: Domain[]
+	domainOptions: AnyDomain[]
 ): DataIdentityOptions => {
 	const { baseUrl, params } = urlComponents;
 

--- a/src/utils/parse-url.ts
+++ b/src/utils/parse-url.ts
@@ -1,14 +1,16 @@
 import { pad } from '.';
+import { getFallbackDomainValue, isSeamlessDomain } from '../domain-helpers';
 
 import {
 	DATA_RELEVANT_PARAMS,
 	DOMAIN_META_REGEX,
 	OM_PREFIX_REGEX,
+	RESOLVE_DOMAIN_REGEX,
 	TILE_SUFFIX_REGEX,
 	TIME_STEP_REGEX
 } from './constants';
 
-import { DomainMetaDataJson, ParsedUrlComponents, TileIndex } from '../types';
+import { AnyDomain, DomainMetaDataJson, ParsedUrlComponents, TileIndex } from '../types';
 
 const parseTileIndex = (url: string): { tileIndex: TileIndex | null; remainingUrl: string } => {
 	const match = url.match(TILE_SUFFIX_REGEX);
@@ -71,18 +73,41 @@ const getModifiedAmount = (amount: number, modifier = '+') => {
 // {meta}.json files are cached for 60 seconds
 const metaDataCache = new Map<string, Promise<DomainMetaDataJson>>();
 
-export const parseMetaJson = async (omUrl: string) => {
+/**
+ * For SeamlessDomain URLs, return the equivalent URL using the global (last-layer)
+ * backing domain so the server request resolves correctly.  The server only serves
+ * concrete domain paths; the seamless domain is a client-side concept.
+ */
+const resolveJsonFetchUrl = (jsonUrl: string, domainOptions?: AnyDomain[]): string => {
+	if (!domainOptions) return jsonUrl;
+	const domainMatch = jsonUrl.match(RESOLVE_DOMAIN_REGEX);
+	const urlDomainValue = domainMatch?.groups?.domain;
+	if (!urlDomainValue) return jsonUrl;
+	const domain = domainOptions.find((d) => d.value === urlDomainValue);
+	if (!domain || !isSeamlessDomain(domain)) return jsonUrl;
+	// domain is a SeamlessDomain — use the last (global fallback) layer for the fetch
+	const backingDomainValue = getFallbackDomainValue(domain);
+	return jsonUrl.replace(
+		`/data_spatial/${urlDomainValue}/`,
+		`/data_spatial/${backingDomainValue}/`
+	);
+};
+
+export const parseMetaJson = async (omUrl: string, domainOptions?: AnyDomain[]) => {
 	let date = new Date();
 	const url = omUrl.replace('om://', '');
 
 	// jsonUrl should be everything until ".json" of the current url (inclusive)
 	const jsonIndex = url.indexOf('.json');
 	const jsonUrl = url.slice(0, jsonIndex + '.json'.length);
+	// For seamless domains, fetch from the global backing domain; cache under the
+	// original (seamless) key so duplicate requests are still deduplicated.
+	const fetchJsonUrl = resolveJsonFetchUrl(jsonUrl, domainOptions);
 
 	if (!metaDataCache.has(jsonUrl)) {
-		const metaRequest = fetch(jsonUrl).then((response) => {
+		const metaRequest = fetch(fetchJsonUrl).then((response) => {
 			if (!response.ok) {
-				throw new Error(`Failed to fetch ${jsonUrl}: ${response.status}`);
+				throw new Error(`Failed to fetch ${fetchJsonUrl}: ${response.status}`);
 			}
 			return response.json() as Promise<DomainMetaDataJson>;
 		});
@@ -157,4 +182,11 @@ export const parseMetaJson = async (omUrl: string) => {
 				`${modelRun.getUTCFullYear()}/${pad(modelRun.getUTCMonth() + 1)}/${pad(modelRun.getUTCDate())}/${pad(modelRun.getUTCHours())}00Z/${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}T${pad(date.getUTCHours())}00.om`
 			)
 	);
+};
+
+export const normalizeUrl = async (url: string, domainOptions?: AnyDomain[]): Promise<string> => {
+	if (url.includes('.json')) {
+		return parseMetaJson(url, domainOptions);
+	}
+	return url;
 };

--- a/src/utils/seamless-sampling.ts
+++ b/src/utils/seamless-sampling.ts
@@ -1,0 +1,217 @@
+/**
+ * Per-point sampling helpers for seamless composite domains.
+ *
+ * Seamless layers are ordered finest-first.  At any geographic point the finest
+ * layer that covers it wins, smoothly blending into the next coarser layer
+ * across each layer's `blendWidthDeg` edge zone (smooth-step 3d²−2d³).  This is
+ * the same blend the raster path uses, factored out here so the vector layers
+ * (arrows, contours, grid points) render continuously across domain boundaries
+ * instead of cutting off at the finest layer's footprint.
+ */
+import type { GridInterface } from '../grids/interface';
+
+import { degreesToRadians, radiansToDegrees } from './math';
+import { computeNanDistanceField } from './nan-distance';
+
+import type { InterpolationMethod, SeamlessLayerRenderData } from '../types';
+
+export type ValueSampler = (lat: number, lon: number) => number;
+
+export interface VectorSample {
+	/** Magnitude (e.g. wind speed). */
+	value: number;
+	/** Direction in degrees, same convention as the source `directions` array. */
+	direction: number;
+}
+
+export type VectorSampler = (lat: number, lon: number) => VectorSample;
+
+// Worker-side cache of NaN-distance fields, keyed by `layer.nanFieldKey` (stable
+// per data URL + ranges). Computed once per timestep/viewport and reused across
+// tiles. A `null` entry records "computed, no field" so non-padded grids aren't
+// rescanned on every tile.
+const nanFieldCache = new Map<string, Float32Array | null>();
+const MAX_NAN_FIELDS = 16;
+
+const getNanField = (layer: SeamlessLayerRenderData): Float32Array | undefined => {
+	const key = layer.nanFieldKey;
+	if (!key) return undefined;
+	if (nanFieldCache.has(key)) return nanFieldCache.get(key) ?? undefined;
+
+	let field: Float32Array | undefined;
+	const values = layer.data.values;
+	const grid = layer.domain.grid;
+	if (values && grid.type === 'regular') {
+		const nx = layer.ranges[1].end - layer.ranges[1].start;
+		const ny = layer.ranges[0].end - layer.ranges[0].start;
+		field = computeNanDistanceField(values, nx, ny, grid.dx!, grid.dy!);
+	}
+
+	if (nanFieldCache.size >= MAX_NAN_FIELDS) {
+		const oldest = nanFieldCache.keys().next().value;
+		if (oldest !== undefined) nanFieldCache.delete(oldest);
+	}
+	nanFieldCache.set(key, field ?? null);
+	return field;
+};
+
+/**
+ * Smooth-step weight of `layer` at (lat, lon): 1 deep inside the layer, falling
+ * to 0 at the edge of its blend zone.  Returns 1 when the layer does not blend
+ * (global fallback / `blendWidthDeg <= 0`).
+ *
+ * The edge distance is the smaller of:
+ *  - the distance to the domain boundary (`fullGrid.edgeDistanceDeg`), which is
+ *    projection-aware so the band follows a curved boundary; and
+ *  - the distance to the nearest NaN cell (`field`), so the band also follows the
+ *    real data shape of NULL-padded regular grids.
+ */
+const edgeBlendWeight = (
+	fullGrid: GridInterface,
+	valueGrid: GridInterface,
+	field: Float32Array | undefined,
+	layer: SeamlessLayerRenderData,
+	lat: number,
+	lon: number
+): number => {
+	if (layer.blendWidthDeg <= 0) return 1;
+	let dist = fullGrid.edgeDistanceDeg(lat, lon);
+	if (field) {
+		const nanDist = valueGrid.getLinearInterpolatedValue(field, lat, lon);
+		if (isFinite(nanDist)) dist = Math.min(dist, nanDist);
+	}
+	const d = dist / layer.blendWidthDeg;
+	if (d <= 0) return 0;
+	if (d >= 1) return 1;
+	return d * d * (3 - 2 * d); // smooth-step
+};
+
+/**
+ * Recursively samples and blends a scalar field from seamless layers, starting
+ * at `startIdx`.  Skips layers that do not cover the point (NaN) and blends with
+ * the next coarser layer(s) inside the edge zone.
+ */
+const blendValue = (
+	layerGrids: GridInterface[],
+	edgeGrids: GridInterface[],
+	fields: (Float32Array | undefined)[],
+	seamlessLayers: SeamlessLayerRenderData[],
+	lat: number,
+	lon: number,
+	startIdx: number,
+	method: InterpolationMethod
+): number => {
+	for (let i = startIdx; i < seamlessLayers.length; i++) {
+		const layer = seamlessLayers[i];
+		const vals = layer.data.values;
+		if (!vals) continue;
+
+		const value = layerGrids[i].getInterpolatedValue(vals, lat, lon, method);
+		if (!isFinite(value)) continue; // point not covered by this domain
+
+		if (i === seamlessLayers.length - 1) return value;
+		const t = edgeBlendWeight(edgeGrids[i], layerGrids[i], fields[i], layer, lat, lon);
+		if (t >= 1) return value;
+
+		const fallback = blendValue(
+			layerGrids,
+			edgeGrids,
+			fields,
+			seamlessLayers,
+			lat,
+			lon,
+			i + 1,
+			method
+		);
+		if (!isFinite(fallback)) return value;
+		return value * t + fallback * (1 - t);
+	}
+	return NaN;
+};
+
+/**
+ * Blends a scalar field across all seamless layers at (lat, lon).
+ *
+ * `layerGrids` index the (possibly viewport-cropped) data arrays; `edgeGrids` are
+ * the full-domain grids used to measure the blend edge distance, so the blend
+ * follows the real domain boundary rather than the tile/viewport crop. They
+ * default to `layerGrids` for callers that pass full-domain grids for both.
+ */
+export const sampleBlendedValue = (
+	layerGrids: GridInterface[],
+	seamlessLayers: SeamlessLayerRenderData[],
+	edgeGrids: GridInterface[] = layerGrids,
+	method: InterpolationMethod = 'linear'
+): ValueSampler => {
+	const fields = seamlessLayers.map(getNanField);
+	return (lat, lon) =>
+		blendValue(layerGrids, edgeGrids, fields, seamlessLayers, lat, lon, 0, method);
+};
+
+/**
+ * Recursively blends a wind vector across seamless layers.  Blending happens in
+ * U/V component space so both magnitude and direction stay continuous across
+ * domain seams (averaging raw bearings would wrap incorrectly near 0°/360°).
+ */
+const blendVector = (
+	layerGrids: GridInterface[],
+	edgeGrids: GridInterface[],
+	fields: (Float32Array | undefined)[],
+	seamlessLayers: SeamlessLayerRenderData[],
+	lat: number,
+	lon: number,
+	startIdx: number,
+	method: InterpolationMethod
+): { u: number; v: number } | null => {
+	for (let i = startIdx; i < seamlessLayers.length; i++) {
+		const layer = seamlessLayers[i];
+		const vals = layer.data.values;
+		const dirs = layer.data.directions;
+		if (!vals || !dirs) continue;
+
+		// Sample the magnitude with the selected method so arrow size/colour
+		// matches the raster; direction is blended circularly (scalar averaging
+		// flips arrows near the 0°/360° seam).
+		const speed = layerGrids[i].getInterpolatedValue(vals, lat, lon, method);
+		if (!isFinite(speed)) continue; // point not covered by this domain
+
+		const rad = degreesToRadians(layerGrids[i].getLinearInterpolatedDirection(dirs, lat, lon));
+		const u = speed * Math.sin(rad);
+		const v = speed * Math.cos(rad);
+
+		if (i === seamlessLayers.length - 1) return { u, v };
+		const t = edgeBlendWeight(edgeGrids[i], layerGrids[i], fields[i], layer, lat, lon);
+		if (t >= 1) return { u, v };
+
+		const fallback = blendVector(
+			layerGrids,
+			edgeGrids,
+			fields,
+			seamlessLayers,
+			lat,
+			lon,
+			i + 1,
+			method
+		);
+		if (!fallback) return { u, v };
+		return { u: u * t + fallback.u * (1 - t), v: v * t + fallback.v * (1 - t) };
+	}
+	return null;
+};
+
+/** Blends a wind vector (magnitude + direction) across all seamless layers. */
+export const sampleBlendedVector = (
+	layerGrids: GridInterface[],
+	seamlessLayers: SeamlessLayerRenderData[],
+	edgeGrids: GridInterface[] = layerGrids,
+	method: InterpolationMethod = 'linear'
+): VectorSampler => {
+	const fields = seamlessLayers.map(getNanField);
+	return (lat, lon) => {
+		const uv = blendVector(layerGrids, edgeGrids, fields, seamlessLayers, lat, lon, 0, method);
+		if (!uv) return { value: NaN, direction: NaN };
+		let direction = radiansToDegrees(Math.atan2(uv.u, uv.v));
+		if (direction < 0) direction += 360;
+		return { value: Math.hypot(uv.u, uv.v), direction };
+	};
+};

--- a/src/worker-pool-instance.ts
+++ b/src/worker-pool-instance.ts
@@ -1,0 +1,8 @@
+import { WorkerPool } from './worker-pool';
+
+/**
+ * Shared WorkerPool singleton used by all protocol handler modules.
+ * Centralised here so both om-protocol.ts and om-protocol-seamless.ts
+ * can import the same instance without creating duplicate pools.
+ */
+export const workerPool = new WorkerPool();

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -4,13 +4,19 @@ import { generateArrows } from './utils/arrows';
 import { checkAgainstBounds } from './utils/bounds';
 import { clipRasterToPolygons } from './utils/clipping';
 import { generateContours } from './utils/contours';
-import { generateGridPoints } from './utils/grid-points';
+import { type GridPointSource, generateGridPoints } from './utils/grid-points';
 import { halfQuantum as computeHalfQuantum, tile2lat, tile2lon } from './utils/math';
+import {
+	type ValueSampler,
+	type VectorSampler,
+	sampleBlendedValue,
+	sampleBlendedVector
+} from './utils/seamless-sampling';
 import { makeColorSampler } from './utils/styling';
 
 import { GridFactory } from './grids/index';
 
-import { WorkerRequest } from './types';
+import type { Domain, WorkerRequest } from './types';
 
 self.onmessage = async (message: MessageEvent<WorkerRequest>): Promise<void> => {
 	const key = message.data.key;
@@ -30,8 +36,11 @@ self.onmessage = async (message: MessageEvent<WorkerRequest>): Promise<void> => 
 	const colorBlend = message.data.renderOptions.colorBlend;
 	const colorScale = message.data.renderOptions.colorScale;
 	const clippingOptions = message.data.clippingOptions;
+	const seamlessLayers = message.data.seamlessLayers;
+	const isSeamless = seamlessLayers !== undefined && seamlessLayers.length > 0;
 
-	if (!values) {
+	// For non-seamless requests, values must be present
+	if (!values && !isSeamless) {
 		throw new Error('No values provided');
 	}
 
@@ -40,7 +49,21 @@ self.onmessage = async (message: MessageEvent<WorkerRequest>): Promise<void> => 
 		// Initialized with zeros
 		const rgba = new Uint8ClampedArray(pixels * 4);
 
-		const grid = GridFactory.create(domain.grid, ranges);
+		// Build the per-pixel value sampler
+		let getPixelValue: ValueSampler;
+		if (seamlessLayers && seamlessLayers.length > 0) {
+			// Pre-create all layer grids once (outside the pixel loop for efficiency)
+			const layerGrids = seamlessLayers.map((layer) =>
+				GridFactory.create(layer.domain.grid, layer.ranges)
+			);
+			// Full-domain grids (uncropped) so the blend edge distance follows the real
+			// domain boundary instead of the viewport crop.
+			const fullGrids = seamlessLayers.map((layer) => GridFactory.create(layer.domain.grid, null));
+			getPixelValue = sampleBlendedValue(layerGrids, seamlessLayers, fullGrids, interpolation);
+		} else {
+			const grid = GridFactory.create((domain as Domain).grid, ranges);
+			getPixelValue = (lat, lon) => grid.getInterpolatedValue(values!, lat, lon, interpolation);
+		}
 
 		// Offset the colour threshold by half the data's quantization step so
 		// band edges fall inside grid cells (smooth) instead of snapping to the
@@ -79,7 +102,7 @@ self.onmessage = async (message: MessageEvent<WorkerRequest>): Promise<void> => 
 					if (checkAgainstBounds(lon, clippingOptions.bounds[0], clippingOptions.bounds[2]))
 						continue;
 
-				const px = grid.getInterpolatedValue(values, lat, lon, interpolation);
+				const px = getPixelValue(lat, lon);
 
 				if (isFinite(px)) {
 					const color = sampleColor(px + halfQuantum, colorOut);
@@ -112,29 +135,61 @@ self.onmessage = async (message: MessageEvent<WorkerRequest>): Promise<void> => 
 		postMessage({ type: 'returnImage', tile: imageBitmap, key: key }, { transfer: [imageBitmap] });
 	} else if (message.data.type == 'getArrayBuffer') {
 		const directions = message.data.data.directions;
+		const renderOptions = message.data.renderOptions;
 
 		const pbf = new PbfWriter();
 
-		const grid = GridFactory.create(domain.grid, ranges);
-		if (message.data.renderOptions.drawGrid) {
-			generateGridPoints(pbf, grid, values, directions, x, y, z, clippingOptions);
+		// Build per-point samplers + grid-point sources.  For seamless domains these
+		// blend across all active layers (finest-first) so arrows, contours and grid
+		// points stay continuous instead of cutting off at the finest domain's edge.
+		let sampleValue: ValueSampler;
+		let sampleVector: VectorSampler;
+		let gridSources: GridPointSource[];
+
+		if (seamlessLayers && seamlessLayers.length > 0) {
+			const layerGrids = seamlessLayers.map((layer) =>
+				GridFactory.create(layer.domain.grid, layer.ranges)
+			);
+			// Full-domain grids (uncropped) so the blend edge distance follows the real
+			// domain boundary instead of the viewport crop.
+			const fullGrids = seamlessLayers.map((layer) => GridFactory.create(layer.domain.grid, null));
+			sampleValue = sampleBlendedValue(layerGrids, seamlessLayers, fullGrids, interpolation);
+			sampleVector = sampleBlendedVector(layerGrids, seamlessLayers, fullGrids, interpolation);
+			gridSources = seamlessLayers.map((layer, i) => ({
+				grid: layerGrids[i],
+				values: layer.data.values ?? new Float32Array(0),
+				directions: layer.data.directions
+			}));
+		} else {
+			const grid = GridFactory.create((domain as Domain).grid, ranges);
+			const vectorValues = values ?? new Float32Array(0);
+			sampleValue = (lat, lon) => grid.getInterpolatedValue(vectorValues, lat, lon, interpolation);
+			// Sample the magnitude with the selected method so arrow size/colour
+			// matches the raster; direction is blended circularly (scalar averaging
+			// flips arrows near the 0°/360° seam).
+			sampleVector = (lat, lon) => ({
+				value: grid.getInterpolatedValue(vectorValues, lat, lon, interpolation),
+				direction: directions ? grid.getLinearInterpolatedDirection(directions, lat, lon) : 0
+			});
+			gridSources = [{ grid, values: vectorValues, directions }];
 		}
-		if (message.data.renderOptions.drawArrows && directions) {
-			generateArrows(pbf, values, directions, grid, x, y, z, clippingOptions, interpolation);
+
+		if (renderOptions.drawGrid) {
+			generateGridPoints(pbf, gridSources, x, y, z, clippingOptions);
 		}
-		if (message.data.renderOptions.drawContours) {
-			const intervals = message.data.renderOptions.intervals;
+		if (renderOptions.drawArrows && directions) {
+			generateArrows(pbf, sampleVector, x, y, z, clippingOptions);
+		}
+		if (renderOptions.drawContours) {
 			generateContours(
 				pbf,
-				values,
-				grid,
+				sampleValue,
 				x,
 				y,
 				z,
 				tileSize,
-				intervals,
+				renderOptions.intervals,
 				clippingOptions,
-				interpolation,
 				computeHalfQuantum(message.data.data.scaleFactor)
 			);
 		}


### PR DESCRIPTION
The feature itself: a `SeamlessDomain` is a stack of concrete domains, finest
first, blended per pixel where they overlap.

- `SeamlessDomain`/`AnyDomain` types, the domain definitions and helpers
- `om-protocol-seamless.ts`: picks active layers per zoom, skips those outside
  the viewport or past their `maxForecastHours`, loads the rest in parallel
- `seamless-sampling.ts`: the per-pixel blend
- wiring through the protocol, the worker and the renderers

One behaviour fix worth flagging: the state cap is now sized by active layer
count. A composite holds one state per sub-layer, so at the default cap of 2
every tile request evicted what the next one needed and re-read it — two tests
cover that now.

Necessarily one commit: introducing the `AnyDomain` union forces every
`domain.grid` call site to change with it, and those call sites need the
seamless module.

Verified: tsc clean, 269 tests pass.
